### PR TITLE
Fix compatibility issue with DR v8+

### DIFF
--- a/spell_rev/change-log.txt
+++ b/spell_rev/change-log.txt
@@ -38,6 +38,7 @@ V4 - Beta 19
 - Fix inconsistency in Improved Haste description
 - Fix Protection from Elemental Energy not working
 - Fix icons for Obscuring Mist and Monster Summoning I scrolls (thanks NdranC and aenri)
+- Fix compatibility issue with Divine Remix v8+
 
 V4 - Beta 18 (24 November 2019) - updated by Mike1072
 - Use IWDEE icon for Sunscorch

--- a/spell_rev/setup-spell_rev.tp2
+++ b/spell_rev/setup-spell_rev.tp2
@@ -234,7 +234,7 @@ INCLUDE ~spell_rev/lib/joinable_npcs.tpa~
 LAM ~JOINABLE_NPC_ARRAYS~
 
 // remove old spells, add new ones
-ACTION_IF NOT MOD_IS_INSTALLED ~Divine_Remix~ ~0~ BEGIN
+ACTION_IF NOT MOD_IS_INSTALLED ~Divine_Remix~ ~1000~ BEGIN
   INCLUDE ~spell_rev/components/fix_divine_spellbooks.tpa~
 END
 


### PR DESCRIPTION
The component number for Divine Remix's sphere system changed from 0 to 1000 in v8, so the check in the spellbook-updating component needs to be updated to match. This fixes #38.