### PR TITLE
remove install blockers

### DIFF
--- a/spell_rev/components/main_component.tpa
+++ b/spell_rev/components/main_component.tpa
@@ -598,7 +598,7 @@ ACTION_IF NOT (FILE_EXISTS_IN_GAME "dvknbck.spl") BEGIN
 END ELSE BEGIN
   FAIL "File 'dvknbck.spl' already exists in game."
 END
-ACTION_IF NOT (FILE_EXISTS_IN_GAME "dvknbck.spl") BEGIN
+ACTION_IF NOT (FILE_EXISTS_IN_GAME "dvknbck.eff") BEGIN
   COPY ~spell_rev\sppr2##\dvknbck.eff~    ~override~
 END ELSE BEGIN
   FAIL "File 'dvknbck.eff' already exists in game."
@@ -694,8 +694,6 @@ COPY ~spell_rev\sppr3##\sppr312.spl~     ~override~  // Strength of One
 
 COPY ~spell_rev\sppr3##\sppr313.spl~     ~override~  // Holy Smite
   SAY NAME1 @95    SAY UNIDENTIFIED_DESC @96
-COPY ~spell_rev\sppr3##\sppr313d.spl~     ~override~
-COPY ~spell_rev\sppr3##\sppr313.eff~     ~override~
 COPY ~spell_rev\projectles\pholyst.pro~ ~override~
 /* COPY_EXISTING ~pholyst.pro~ ~override~
   WRITE_SHORT 0x204 190
@@ -703,8 +701,6 @@ COPY ~spell_rev\projectles\pholyst.pro~ ~override~
 
 COPY ~spell_rev\sppr3##\sppr314.spl~     ~override~  // Unholy Blight
   SAY NAME1 @97    SAY UNIDENTIFIED_DESC @98
-COPY ~spell_rev\sppr3##\sppr314d.spl~     ~override~
-COPY ~spell_rev\sppr3##\sppr314.eff~     ~override~
 COPY ~spell_rev\projectles\punhlst.pro~ ~override~
 /* COPY_EXISTING ~punhlst.pro~ ~override~
   WRITE_SHORT 0x204 190

--- a/spell_rev/lib/kreso_haste_slow.tph
+++ b/spell_rev/lib/kreso_haste_slow.tph
@@ -135,7 +135,6 @@ ACTION_IF  FILE_EXISTS_IN_GAME ~potn14.spl~ BEGIN // IR Oil of Speed - commented
 COPY_EXISTING ~potn14.spl~ ~override~  
  LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 221 header = 0 END
  WRITE_BYTE 0x27 "%k1#Haste%"
- END
   LPF ADD_SPELL_EFFECT
 	INT_VAR
 	opcode			= 221


### PR DESCRIPTION
I had some hard failures while playtesting the changes that are on master.
These may not be the desired fixes.
- in two cases, files where deleted in previous commit (`sppr3##\sppr313d.spl/eff` and `sppr3##\sppr314d.spl/eff`) so I just removed _uses_ (COPY) of these files but maybe the deleting itself was undesired or it should have been replaced by something else?
- in `kreso_haste_slow.tph`, you just get a parsing error because or a spurious `END`. I *think* I removed the correct one but as there are three of them and indentation is... random I'm not sure.
- the last one, `ACTION_IF NOT (FILE_EXISTS_IN_GAME "dvknbck.eff") BEGIN` I interpreted as a copy/paste error (testing for one `.spl` file and doig an action on the `.eff` one).