### PR TITLE
Fix indentation and similar issues

### DIFF
--- a/spell_rev/lib/dispelling_screen.tph
+++ b/spell_rev/lib/dispelling_screen.tph
@@ -7,28 +7,30 @@ INCLUDE ~spell_rev\lib\macros.tpa~ // needed since I dug a hole for myself
 ADD_SECTYPE ~k1#Dispel~ @21000 // add a string reference for removal, like ~Dispelling Screen Dissipates~ or something
 
 COPY_EXISTING ~msectype.2da~ ~override~
-  COUNT_2DA_ROWS "2" "sectype_k1#Dispel"
-  SET "sectype_k1#Dispel" -= "2"
-  PRETTY_PRINT_2DA
+  	COUNT_2DA_ROWS "2" "sectype_k1#Dispel"
+  	SET "sectype_k1#Dispel" -= "2"
+  	PRETTY_PRINT_2DA
  
  // 16.1.2016... if I go build this spell via code, SRv4 will see the light of day year 2056...//
  // 17.1.2016....I did it... :)//
  
-LAF CREATE_SPELL STR_VAR spell=~k1#scre~ END  // Could be simpler....
+// TO DO: kill the damn "Display String" and "remove portait icon" opcodes from all removal spells
+// they're automatically displayed once they remove something, so now they display twice.
+LAF CREATE_SPELL STR_VAR spell=~k1#scre~ END
 COPY_EXISTING ~k1#scre.spl~ override
-SAY NAME1 @21001   SAY UNIDENTIFIED_DESC @21001
-LPF ADD_SPELL_HEADER INT_VAR type = 1 level = 5 power = 5 projectile = 158 range = 30 END // 
- LPF ADD_SPELL_EFFECT 
-INT_VAR
-opcode = 206
-duration = 300
-power = 5
-timing = 0
-resist_dispel = 2
-target = 2
-STR_VAR
-resource = spwi513b // TO DO: kill the damn "Display String" and "remove portait icon" opcodes from all removal spells
- END                // they're automatically displayed once they remove something, so now they display twice.
+  	SAY NAME1 @21001
+  	SAY UNIDENTIFIED_DESC @21001
+  	LPF ADD_SPELL_HEADER INT_VAR type = 1 level = 5 power = 5 projectile = 158 range = 30 END
+  	LPF ADD_SPELL_EFFECT INT_VAR
+		opcode = 206
+		duration = 300
+		power = 5
+		timing = 0
+		resist_dispel = 2
+		target = 2
+  	STR_VAR
+		resource = "spwi513b"
+  	END
  
  /* LPF ADD_SPELL_EFFECT   // This is commented out. I made all these resources use 146 to cast Breach. *Much* better overall...
 INT_VAR
@@ -66,132 +68,141 @@ STR_VAR
 resource = wand18a
  END */ 
 
- LPF ADD_SPELL_EFFECT  // Immunity to dispels
-INT_VAR
-opcode = 101
-duration = 300
-resist_dispel = 2
-power = 5
-timing = 0
-target = 2
-parameter2 = 58
-STR_VAR
- END
+	// Immunity to dispels
+	LPF ADD_SPELL_EFFECT INT_VAR
+	  	opcode = 101
+	  	duration = 300
+	  	resist_dispel = 2
+	  	power = 5
+	  	timing = 0
+	  	target = 2
+	  	parameter2 = 58
+	END
 
- LPF ADD_SPELL_EFFECT  // Portrait icon; should be renamed....something like "Protected by Dispelling Screen"
-INT_VAR
-opcode = 142
-duration = 300
-power = 5
-timing = 0
-resist_dispel = 2
-target = 2
-parameter2 = 107
-STR_VAR
- END
+	// Portrait icon; should be renamed....something like "Protected by Dispelling Screen"
+	LPF ADD_SPELL_EFFECT INT_VAR
+	  	opcode = 142
+	  	duration = 300
+	  	power = 5
+	  	timing = 0
+	  	resist_dispel = 2
+	  	target = 2
+	  	parameter2 = 107
+	END
 
- LPF ADD_SPELL_EFFECT  // plays animation
-INT_VAR
-opcode = 215
-duration = 300
-power = 5
-timing = 0
-target = 2
-resist_dispel = 2
-parameter2 = 1
-STR_VAR
-resource = spturni2
- END
+	// plays animation
+	LPF ADD_SPELL_EFFECT INT_VAR
+	  	opcode = 215
+	  	duration = 300
+	  	power = 5
+	  	timing = 0
+	  	target = 2
+	  	resist_dispel = 2
+	  	parameter2 = 1
+	STR_VAR
+	  	resource = "spturni2"
+	END
 
- LPF ADD_SPELL_EFFECT
-INT_VAR
-opcode = 267   // "Dispel Effects" string immunity
-duration = 300
-power = 5
-resist_dispel = 2
-timing = 0
-target = 2
-parameter1 = 14056  
-STR_VAR
-END
+	LPF ADD_SPELL_EFFECT INT_VAR
+	  	opcode = 267   // "Dispel Effects" string immunity
+	  	parameter1 = 14056  
+	  	duration = 300
+	  	power = 5
+	  	resist_dispel = 2
+	  	timing = 0
+	  	target = 2
+	END
  
 COPY_EXISTING ~spwi510.spl~ ~override~  
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = "-1" header = 1 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 146 target = 1 parameter2 = 1 power = 5 header =1 STR_VAR resource = k1#scre END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 215 target = 2 parameter2 = 1 power = 5 header =1 STR_VAR resource = sprotect duration = 4 END
+  	LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = "-1" header = 1 END
+  	LPF ADD_SPELL_EFFECT INT_VAR opcode = 146 target = 1 parameter2 = 1 power = 5 header =1 STR_VAR resource = "k1#scre" END
+  	LPF ADD_SPELL_EFFECT INT_VAR opcode = 215 target = 2 parameter2 = 1 power = 5 header =1 STR_VAR resource = "sprotect" duration = 4 END
 
 COPY_EXISTING ~spwi590.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = "-1" header = 1 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 146 target = 1 parameter2 = 1 power = 5 header =1 STR_VAR resource = k1#scre END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 215 target = 2 parameter2 = 1 power = 5 header =1 STR_VAR resource = sprotect duration = 4 END
+  	LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = "-1" header = 1 END
+  	LPF ADD_SPELL_EFFECT INT_VAR opcode = 146 target = 1 parameter2 = 1 power = 5 header =1 STR_VAR resource = "k1#scre" END
+  	LPF ADD_SPELL_EFFECT INT_VAR opcode = 215 target = 2 parameter2 = 1 power = 5 header =1 STR_VAR resource = "sprotect" duration = 4 END
 
 COPY_EXISTING ~k1#scre.spl~ ~override~  //sectype marker
-WRITE_BYTE 0x27 "%k1#Dispel%"
+  	WRITE_BYTE 0x27 "%k1#Dispel%"
 
-COPY_EXISTING ~spwi519.spl~ ~override~   // SS shouldn't stop Breach anymore
-LPF DELETE_EFFECT 
-INT_VAR
- match_opcode = 206
- STR_VAR
- match_resource = spwi513b END
+COPY_EXISTING ~spwi519.spl~ ~override~  //SS shouldn't stop Breach anymore
+  	LPF DELETE_EFFECT INT_VAR
+  	  	match_opcode = 206
+  	STR_VAR
+  	  	match_resource = "spwi513b"
+  	END
  
 
 // GLOBAL CHANGES  // 
-
- COPY_EXISTING_REGEXP GLOB ~.*\.itm~ ~override~
- PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
- LPF CLONE_EFFECT INT_VAR match_opcode = 58 opcode = 221 parameter1 = 9 parameter2 = %sectype_k1#Dispel% savingthrow = 0 timing = 3 silent = 1 insert_point = 10 END
- END
- BUT_ONLY_IF_IT_CHANGES
+COPY_EXISTING_REGEXP GLOB ~.*\.itm~ ~override~
+  	PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
+    	LPF CLONE_EFFECT INT_VAR
+    	  	match_opcode = 58
+    	  	opcode = 221
+    	  	parameter1 = 9
+    	  	parameter2 = "%sectype_k1#Dispel%"
+    	  	savingthrow = 0
+    	  	timing = 3
+    	  	silent = 1
+    	  	insert_point = 10 
+    	END
+  	END
+BUT_ONLY_IF_IT_CHANGES
  
- COPY_EXISTING_REGEXP GLOB ~.*\.spl~ ~override~
- PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
- LPF CLONE_EFFECT INT_VAR match_opcode = 58 opcode = 221 parameter1 = 9 parameter2 = %sectype_k1#Dispel% savingthrow = 0 timing = 3 insert_point = 10 silent = 1 END
- END
- BUT_ONLY_IF_IT_CHANGES
- 
- 
+COPY_EXISTING_REGEXP GLOB ~.*\.spl~ ~override~
+  	PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
+    	LPF CLONE_EFFECT INT_VAR
+		  	match_opcode = 58
+		  	opcode = 221
+		  	parameter1 = 9
+		  	parameter2 = "%sectype_k1#Dispel%"
+		  	savingthrow = 0
+		  	timing = 3
+		  	insert_point = 10
+		  	silent = 1
+		END
+   	END
+BUT_ONLY_IF_IT_CHANGES
 
 ///END OF GLOBAL CHANGES///
   
-  // PATCH BREACH TYPE STUFF; with code on the fly //
+// PATCH BREACH TYPE STUFF; with code on the fly //
+ACTION_IF FILE_EXISTS_IN_GAME ~spwi513c.spl~ BEGIN   
+	COPY_EXISTING ~spwi513c.spl~ ~override~  // 
+		LPF ALTER_SPELL_EFFECT INT_VAR
+			match_opcode = 230
+			new_opcode = 221
+			parameter1 = 9
+			parameter2  = EVALUATE_BUFFER "%sectype_k1#Dispel%"
+		END
 
-ACTION_IF  FILE_EXISTS_IN_GAME ~spwi513c.spl~ BEGIN   
-COPY_EXISTING ~spwi513c.spl~ ~override~  // 
-LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 230 new_opcode = 221 parameter1 = 9 parameter2  = EVALUATE_BUFFER %sectype_k1#Dispel% STR_VAR END
-
-ACTION_IF  FILE_EXISTS_IN_GAME ~spwi805b.spl~ BEGIN       
-COPY_EXISTING ~spwi805b.spl~ ~override~  // patch for Pierce Shield  so it breaks DS; SPell shield stops it however
-LPF ADD_SPELL_EFFECT
-	INT_VAR
-	opcode			= 221 // remove type protection
-	target			= 2    //preset
-	power			= 8    
-    parameter1		= 9
-	parameter2		= EVALUATE_BUFFER %sectype_k1#Dispel%
-	timing			= 3
-END
-  BUT_ONLY
+	ACTION_IF FILE_EXISTS_IN_GAME ~spwi805b.spl~ BEGIN       
+		COPY_EXISTING ~spwi805b.spl~ ~override~  // patch for Pierce Shield so it breaks DS; SPell shield stops it however
+			LPF ADD_SPELL_EFFECT INT_VAR
+				opcode = 221 // remove type protection
+				target = 2
+				power = 8    
+    			parameter1 = 9
+				parameter2 = EVALUATE_BUFFER "%sectype_k1#Dispel%"
+				timing = 3
+			END
+  		BUT_ONLY
  
-ACTION_IF  FILE_EXISTS_IN_GAME ~spwi903b.spl~ BEGIN   
-COPY_EXISTING ~spwi903b.spl~ ~override~  // patch for Spellstrike
-LPF ADD_SPELL_EFFECT
-	INT_VAR
-	opcode			= 221 // remove type protection
-	target			= 2    //preset
-	power			= 9 
-    parameter1      = 9    
-	parameter2		= EVALUATE_BUFFER %sectype_k1#Dispel%
-	timing			= 3
+		ACTION_IF  FILE_EXISTS_IN_GAME ~spwi903b.spl~ BEGIN
+			COPY_EXISTING ~spwi903b.spl~ ~override~  // patch for Spellstrike
+				LPF ADD_SPELL_EFFECT INT_VAR
+					opcode			= 221 // remove type protection
+					target			= 2    //preset
+					power			= 9 
+					parameter1      = 9    
+					parameter2		= EVALUATE_BUFFER "%sectype_k1#Dispel%"
+					timing			= 3
+				END
+			BUT_ONLY
+		END
+	END
 END
-  BUT_ONLY
-  
-
-END
-END
-END
-
-
 
 /* ACTION_IF  FILE_EXISTS_IN_GAME ~wand18a.spl~ BEGIN  // IR Wand. I'll recreate it when I get the will to do so, so it doesnt
    COPY_EXISTING ~wand18a.spl~ ~override~     // summon Cowled wizards

--- a/spell_rev/lib/insects.tph
+++ b/spell_rev/lib/insects.tph
@@ -4,40 +4,39 @@
 ADD_SECTYPE ~k1insect~ @21002 // change this to "Insects Dispersed" or whatever
  
 COPY_EXISTING ~msectype.2da~ ~override~
-  COUNT_2DA_ROWS "2" "sectype_k1insect"
-  SET "sectype_k1insect" -= "2"
-  PRETTY_PRINT_2DA
+   COUNT_2DA_ROWS "2" "sectype_k1insect"
+   SET "sectype_k1insect" -= "2"
+PRETTY_PRINT_2DA
   
 LAF CREATE_SPELL STR_VAR spell=~k1#inse~ END
 COPY_EXISTING ~k1#inse.spl~ override
-LPF ADD_SPELL_HEADER INT_VAR type=1 level=2 projectile=158 END // change projectile number..??
-    LPF ADD_SPELL_EFFECT
-INT_VAR
-opcode = 221
-target = 2
-power = 0
-level = 2
-parameter1 = 9
-parameter2 = EVALUATE_BUFFER %sectype_k1insect%
-timing = 1
-header = 1
-insert_point = 1
+   LPF ADD_SPELL_HEADER INT_VAR type=1 level=2 projectile=158 END // change projectile number..??
+   LPF ADD_SPELL_EFFECT INT_VAR
+      opcode = 221
+      target = 2
+      power = 0
+      level = 2
+      parameter1 = 9
+      parameter2 = EVALUATE_BUFFER "%sectype_k1insect%"
+      timing = 1
+      header = 1
+      insert_point = 1
    END
- BUT_ONLY
+BUT_ONLY
 
 LAF RES_NUM_OF_SPELL_NAME STR_VAR spell_name = ~CLERIC_GUST_OF_WIND_DRUID_VERSION~ RET spell_res END
 COPY_EXISTING ~%spell_res%.spl~ ~override~ 
-LPF ADD_SPELL_EFFECT  
-      INT_VAR
-   opcode = 146
-   target = 1 // self
-   parameter1 = 0  
-   parameter2 = 1
-   power = 0   
-      STR_VAR
-        resource = k1#inse
-END
+   LPF ADD_SPELL_EFFECT INT_VAR
+      opcode = 146
+      target = 1 // self
+      parameter1 = 0  
+      parameter2 = 1
+      power = 0   
+   STR_VAR
+      resource = "k1#inse"
+   END
 BUT_ONLY
+
 /*
 COPY_EXISTING ~sppr318.spl~ ~override~
 LPF ADD_SPELL_EFFECT
@@ -52,17 +51,21 @@ LPF ADD_SPELL_EFFECT
 END
 BUT_ONLY
 */
-COPY_EXISTING ~sppr319a.spl~     ~override~
-WRITE_BYTE 0x27 "%k1insect%" 
-COPY_EXISTING ~sppr319b.spl~     ~override~
-WRITE_BYTE 0x27 "%k1insect%"
+
+COPY_EXISTING ~sppr319a.spl~ ~override~
+   WRITE_BYTE 0x27 "%k1insect%" 
+
+COPY_EXISTING ~sppr319b.spl~ ~override~
+   WRITE_BYTE 0x27 "%k1insect%"
  
-COPY_EXISTING ~sppr517a.spl~     ~override~
-WRITE_BYTE 0x27 "%k1insect%" 
-COPY_EXISTING ~sppr517b.spl~              ~override~
-WRITE_BYTE 0x27 "%k1insect%"
+COPY_EXISTING ~sppr517a.spl~ ~override~
+   WRITE_BYTE 0x27 "%k1insect%" 
+
+COPY_EXISTING ~sppr517b.spl~ ~override~
+   WRITE_BYTE 0x27 "%k1insect%"
  
-COPY_EXISTING ~sppr717a.spl~     ~override~
-WRITE_BYTE 0x27 "%k1insect%" 
-COPY_EXISTING ~sppr717b.spl~     ~override~
-WRITE_BYTE 0x27 "%k1insect%"
+COPY_EXISTING ~sppr717a.spl~ ~override~
+   WRITE_BYTE 0x27 "%k1insect%" 
+
+COPY_EXISTING ~sppr717b.spl~ ~override~
+   WRITE_BYTE 0x27 "%k1insect%"

--- a/spell_rev/lib/kreso_ee.tph
+++ b/spell_rev/lib/kreso_ee.tph
@@ -16,373 +16,372 @@ OUTER_TEXT_SPRINT spwi225 $new_spell_resrefs(~spwi225~)
 OUTER_TEXT_SPRINT spwi526 $new_spell_resrefs(~spwi526~)
 
 ACTION_IF FILE_EXISTS_IN_GAME ~sppr111.spl~ THEN BEGIN  // AoFaith
-COPY_EXISTING ~sppr111.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = sppr111 END
+    COPY_EXISTING ~sppr111.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = "sppr111" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~sppr113.spl~ THEN BEGIN  // Doom
-COPY_EXISTING ~sppr113.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = sppr113 END
+    COPY_EXISTING ~sppr113.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = "sppr113" END
 END
 
 
 ACTION_DEFINE_ARRAY regen_spells BEGIN
-  ~%sppr117%~ // Regenerate Light Wounds
-  ~%sppr217%~ // Regenerate Moderate Wounds
-  ~%sppr323%~ // Regenerate Serious Wounds
-  ~%sppr419%~ // Regenerate Critical Wounds
-  ~%sppr524%~ // Mass Regenerate
-  ~%sppr619%~ // Regeneration (Druid Version)
-  ~sppr711~   // Regeneration
+    ~%sppr117%~ // Regenerate Light Wounds
+    ~%sppr217%~ // Regenerate Moderate Wounds
+    ~%sppr323%~ // Regenerate Serious Wounds
+    ~%sppr419%~ // Regenerate Critical Wounds
+    ~%sppr524%~ // Mass Regenerate
+    ~%sppr619%~ // Regeneration (Druid Version)
+    ~sppr711~   // Regeneration
 END
 
 ACTION_PHP_EACH regen_spells AS i => regen_spell BEGIN
-  ACTION_IF (FILE_EXISTS_IN_GAME ~%regen_spell%.spl~) BEGIN
-    COPY_EXISTING ~%regen_spell%.spl~ ~override~
-      LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-      PHP_EACH regen_spells AS j => regen_spell_inner BEGIN
-        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = EVAL ~%regen_spell_inner%~ END
-      END
-  END
+    ACTION_IF (FILE_EXISTS_IN_GAME ~%regen_spell%.spl~) BEGIN
+        COPY_EXISTING ~%regen_spell%.spl~ ~override~
+            LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+            PHP_EACH regen_spells AS j => regen_spell_inner BEGIN
+                LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = EVAL ~%regen_spell_inner%~ END
+            END
+    END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~sppr201.spl~ THEN BEGIN  // Aid
-COPY_EXISTING ~sppr201.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = sppr201 END
+    COPY_EXISTING ~sppr201.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = "sppr201" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~sppr202.spl~ THEN BEGIN  // Barkskin
-COPY_EXISTING ~sppr202.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = sppr202 END
+    COPY_EXISTING ~sppr202.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = "sppr202" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~sppr203.spl~ THEN BEGIN  // Chant
-COPY_EXISTING ~sppr203.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+    COPY_EXISTING ~sppr203.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~sppr203d.spl~ THEN BEGIN  // Bad Chant
-COPY_EXISTING ~sppr203d.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = sppr203e END
+    COPY_EXISTING ~sppr203d.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = "sppr203e" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~sppr203e.spl~ THEN BEGIN  // Good Chant
-COPY_EXISTING ~sppr203e.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = sppr203d END
+    COPY_EXISTING ~sppr203e.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = "sppr203d" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~sppr209.spl~ THEN BEGIN  // know oponnent
-COPY_EXISTING ~sppr209.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = sppr209 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = spwi208 END
+    COPY_EXISTING ~sppr209.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = "sppr209" END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = "spwi208" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~sppr210.spl~ THEN BEGIN  // pro elements
-COPY_EXISTING ~sppr210.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = sppr210 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = EVAL ~%spwi225%~ END
+    COPY_EXISTING ~sppr210.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = "sppr210" END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = EVAL ~%spwi225%~ END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~sppr312.spl~ THEN BEGIN  // strenght of stone
-COPY_EXISTING ~sppr312.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = sppr312 END
+    COPY_EXISTING ~sppr312.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = "sppr312" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~sppr319b.spl~ THEN BEGIN  // insects
-COPY_EXISTING ~sppr319b.spl~ ~override~
-LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 24 new_opcode = 247 parameter2 = 1 END
+    COPY_EXISTING ~sppr319b.spl~ ~override~
+        LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 24 new_opcode = 247 parameter2 = 1 END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~sppr406.spl~ THEN BEGIN  // def harmony
-COPY_EXISTING ~sppr406.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = sppr406 END
+    COPY_EXISTING ~sppr406.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = "sppr406" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~sppr407.spl~ THEN BEGIN  // pro electric
-COPY_EXISTING ~sppr407.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = sppr407 END
+    COPY_EXISTING ~sppr407.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = "sppr407" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~sppr412.spl~ THEN BEGIN  // holy power
-COPY_EXISTING ~sppr412.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = sppr412 END
+    COPY_EXISTING ~sppr412.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = "sppr412" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~sppr416.spl~ THEN BEGIN  // cloak of fear
-COPY_EXISTING ~sppr416.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = sppr416 END
+    COPY_EXISTING ~sppr416.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = "sppr416" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~sppr513.spl~ THEN BEGIN  // righteous fury
-COPY_EXISTING ~sppr513.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = sppr513 END
+    COPY_EXISTING ~sppr513.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = "sppr513" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~sppr517b.spl~ THEN BEGIN  // insects
-COPY_EXISTING ~sppr517b.spl~ ~override~
-LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 24 new_opcode = 247 parameter2 = 1 END
+    COPY_EXISTING ~sppr517b.spl~ ~override~
+        LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 24 new_opcode = 247 parameter2 = 1 END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~%sppr520%.spl~ THEN BEGIN  // pro acid
-COPY_EXISTING ~%sppr520%.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = EVAL ~%sppr520%~ END
+    COPY_EXISTING ~%sppr520%.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = EVAL ~%sppr520%~ END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~%sppr521%.spl~ THEN BEGIN  // pro cold
-COPY_EXISTING ~%sppr521%.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = EVAL ~%sppr521%~ END
+    COPY_EXISTING ~%sppr521%.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = EVAL ~%sppr521%~ END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~%sppr522%.spl~ THEN BEGIN  // pro electric
-COPY_EXISTING ~%sppr522%.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = EVAL ~%sppr522%~ END
+    COPY_EXISTING ~%sppr522%.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = EVAL ~%sppr522%~ END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~%sppr523%.spl~ THEN BEGIN  // pro fire
-COPY_EXISTING ~%sppr523%.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = EVAL ~%sppr523%~ END
+    COPY_EXISTING ~%sppr523%.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = EVAL ~%sppr523%~ END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~dvpr525d.spl~ THEN BEGIN  // animal growth
-COPY_EXISTING ~dvpr525d.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = dvpr525d END
+    COPY_EXISTING ~dvpr525d.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = "dvpr525d" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~sppr603.spl~ THEN BEGIN  // blade barrier
-COPY_EXISTING ~sppr603.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = sppr603 END
+    COPY_EXISTING ~sppr603.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = "sppr603" END
 END
  
 ACTION_IF FILE_EXISTS_IN_GAME ~sppr717b.spl~ THEN BEGIN  // insects
-COPY_EXISTING ~sppr717b.spl~ ~override~
-LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 24 new_opcode = 247 parameter2 = 1 END
+    COPY_EXISTING ~sppr717b.spl~ ~override~
+        LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 24 new_opcode = 247 parameter2 = 1 END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~sppr725.spl~ THEN BEGIN  // globe of blades
-COPY_EXISTING ~sppr725.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = sppr725 END
+    COPY_EXISTING ~sppr725.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = "sppr725" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~sppr730.spl~ THEN BEGIN  // aura of flaming death
-COPY_EXISTING ~sppr730.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = sppr730 END
+    COPY_EXISTING ~sppr730.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = "sppr730" END
 END
 
 
 /////////////MAGE SPELLS///
 
 ACTION_IF FILE_EXISTS_IN_GAME ~spwi102.spl~ THEN BEGIN  // armor
-COPY_EXISTING ~spwi102.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = spwi102 END
+    COPY_EXISTING ~spwi102.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = "spwi102" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~spwi111.spl~ THEN BEGIN  // true strike
-COPY_EXISTING ~spwi111.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = spwi111 END
+    COPY_EXISTING ~spwi111.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = "spwi111" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~spwi114.spl~ THEN BEGIN  // shield
-COPY_EXISTING ~spwi111.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = spwi114 END
-LPF CLONE_EFFECT INT_VAR match_opcode = 142 opcode = 206 STR_VAR resource = spwi112 END
-LPF CLONE_EFFECT INT_VAR match_opcode = 142 opcode = 206 STR_VAR resource = wand03 END
-LPF CLONE_EFFECT INT_VAR match_opcode = 142 opcode = 206 STR_VAR resource = spwi003 END
+    COPY_EXISTING ~spwi111.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = "spwi114" END
+        LPF CLONE_EFFECT INT_VAR match_opcode = 142 opcode = 206 STR_VAR resource = "spwi112" END
+        LPF CLONE_EFFECT INT_VAR match_opcode = 142 opcode = 206 STR_VAR resource = "wand03" END
+        LPF CLONE_EFFECT INT_VAR match_opcode = 142 opcode = 206 STR_VAR resource = "spwi003" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~spwi201.spl~ THEN BEGIN  // blur
-COPY_EXISTING ~spwi201.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = spwi201 END
+    COPY_EXISTING ~spwi201.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = "spwi201" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~spwi208.spl~ THEN BEGIN  // know oponnent
-COPY_EXISTING ~sppr208.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = sppr209 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = spwi208 END
+    COPY_EXISTING ~sppr208.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = "sppr209" END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = "spwi208" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~spwi209.spl~ THEN BEGIN  // luck
-COPY_EXISTING ~spwi209.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = spwi209 END
+    COPY_EXISTING ~spwi209.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = "spwi209" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~spwi212.spl~ THEN BEGIN  // MI
-COPY_EXISTING ~spwi212.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = spwi120 END
+    COPY_EXISTING ~spwi212.spl~ ~override~
+    LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+    LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = "spwi120" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~%spwi225%.spl~ THEN BEGIN  // pro elements
-COPY_EXISTING ~%spwi225%.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = EVAL ~%spwi225%~ END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = sppr210 END
+    COPY_EXISTING ~%spwi225%.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = EVAL ~%spwi225%~ END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = "sppr210" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~spwi301.spl~ THEN BEGIN  // clairvoyance
-COPY_EXISTING ~spwi301.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = spwi301 END
+    COPY_EXISTING ~spwi301.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = "spwi301" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~spwi315.spl~ THEN BEGIN  // wraithform
-COPY_EXISTING ~spwi315.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = spwi315 END
+    COPY_EXISTING ~spwi315.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = "spwi315" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~spwi317.spl~ THEN BEGIN  // ghost armor
-COPY_EXISTING ~spwi317.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = spwi317 END
+    COPY_EXISTING ~spwi317.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = "spwi317" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~spwi319.spl~ THEN BEGIN  // pro fire
-COPY_EXISTING ~spwi319.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = spwi319 END
+    COPY_EXISTING ~spwi319.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = "spwi319" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~spwi320.spl~ THEN BEGIN  // pro cold
-COPY_EXISTING ~spwi320.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = spwi320 END
+    COPY_EXISTING ~spwi320.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = "spwi320" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~spwi403.spl~ THEN BEGIN  // mesthil
-COPY_EXISTING ~spwi403.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = spwi403 END
+    COPY_EXISTING ~spwi403.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = "spwi403" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~spwi411.spl~ THEN BEGIN  // emotion
-COPY_EXISTING ~spwi411.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = spwi411 END
+    COPY_EXISTING ~spwi411.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = "spwi411" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~spwi412.spl~ THEN BEGIN  // malison
-COPY_EXISTING ~spwi412.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = spwi412 END
+    COPY_EXISTING ~spwi412.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = "spwi412" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~spwi414.spl~ THEN BEGIN  // spirit armor
-COPY_EXISTING ~spwi414.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = spwi414 END
+    COPY_EXISTING ~spwi414.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = "spwi414" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~spwi418.spl~ THEN BEGIN  // fiershield red
-COPY_EXISTING ~spwi418.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = spwi418 END
+    COPY_EXISTING ~spwi418.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = "spwi418" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~spwi512.spl~ THEN BEGIN  // pro electric
-COPY_EXISTING ~spwi512.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = spwi512 END
+    COPY_EXISTING ~spwi512.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = "spwi512" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~spwi517.spl~ THEN BEGIN  // pro acid
-COPY_EXISTING ~spwi517.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = spwi517 END
+    COPY_EXISTING ~spwi517.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = "spwi517" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~%spwi526%.spl~ THEN BEGIN  // mestil
-COPY_EXISTING ~%spwi526%.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = EVAL ~%spwi526%~ END
+    COPY_EXISTING ~%spwi526%.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = EVAL ~%spwi526%~ END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~spwi602.spl~ THEN BEGIN  // goi
-COPY_EXISTING ~spwi602.spl~ ~override~
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = spwi602 END
+    COPY_EXISTING ~spwi602.spl~ ~override~
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = "spwi602" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~spwi606.spl~ THEN BEGIN  // pro mag energy
-COPY_EXISTING ~spwi606.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = spwi606 END
+    COPY_EXISTING ~spwi606.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = "spwi606" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~spwi702.spl~ THEN BEGIN  // pro el energy
-COPY_EXISTING ~spwi702.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = spwi702 END
+    COPY_EXISTING ~spwi702.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = "spwi702" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~spwi708.spl~ THEN BEGIN  // Prism mantle
-COPY_EXISTING ~spwi708.spl~ ~override~
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = spwi708 END
+    COPY_EXISTING ~spwi708.spl~ ~override~
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = "spwi708" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~spwi801.spl~ THEN BEGIN  // ghost
-COPY_EXISTING ~spwi801.spl~ ~override~
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = spwi801 END
+    COPY_EXISTING ~spwi801.spl~ ~override~
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = "spwi801" END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~spwi803.spl~ THEN BEGIN  // pro el energy
-COPY_EXISTING ~spwi803.spl~ ~override~
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = spwi803 END END
+    COPY_EXISTING ~spwi803.spl~ ~override~
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 206 END
+        LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 2 STR_VAR resource = "spwi803" END
+END
  
 
 ACTION_IF FILE_EXISTS_IN_GAME ~spwi808.spl~ THEN BEGIN  // moment of prescience
-COPY_EXISTING ~spwi808.spl~ ~override~
-LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = spwi808 END END 
+    COPY_EXISTING ~spwi808.spl~ ~override~
+    LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 insert_point = 0 target = 1 STR_VAR resource = "spwi808" END
+END 
 
 // EE 2.5 patches by subtledoctor
-//
 ACTION_IF FILE_EXISTS_IN_GAME ~enginest.2da~ BEGIN
+    ACTION_IF FILE_EXISTS_IN_GAME ~spwi318.spl~ THEN BEGIN  // minor deflection
+        COPY_EXISTING ~spwi318.spl~ ~override~
+            LPF ALTER_EFFECT INT_VAR silent = 1 multi_match = 1 match_opcode = 201 STR_VAR resource = ~spwi318b~ END 
+    END
 
- ACTION_IF FILE_EXISTS_IN_GAME ~spwi318.spl~ THEN BEGIN  // minor deflection
- COPY_EXISTING ~spwi318.spl~ ~override~
- LPF ALTER_EFFECT INT_VAR silent = 1 multi_match = 1 match_opcode = 201 STR_VAR resource = ~spwi318b~ END 
- END 
+    ACTION_IF FILE_EXISTS_IN_GAME ~spwi522.spl~ THEN BEGIN  // deflection
+        COPY_EXISTING ~spwi522.spl~ ~override~
+        LPF ALTER_EFFECT INT_VAR silent = 1 multi_match = 1 match_opcode = 201 STR_VAR resource = ~spwi522b~ END 
+    END 
 
- ACTION_IF FILE_EXISTS_IN_GAME ~spwi522.spl~ THEN BEGIN  // deflection
- COPY_EXISTING ~spwi522.spl~ ~override~
- LPF ALTER_EFFECT INT_VAR silent = 1 multi_match = 1 match_opcode = 201 STR_VAR resource = ~spwi522b~ END 
- END 
+    ACTION_IF FILE_EXISTS_IN_GAME ~spwi618.spl~ THEN BEGIN  // deflection
+        COPY_EXISTING ~spwi618.spl~ ~override~
+        LPF ALTER_EFFECT INT_VAR silent = 1 multi_match = 1 match_opcode = 201 STR_VAR resource = ~spwi618b~ END 
+    END 
 
- ACTION_IF FILE_EXISTS_IN_GAME ~spwi618.spl~ THEN BEGIN  // deflection
- COPY_EXISTING ~spwi618.spl~ ~override~
- LPF ALTER_EFFECT INT_VAR silent = 1 multi_match = 1 match_opcode = 201 STR_VAR resource = ~spwi618b~ END 
- END 
-
- ACTION_IF FILE_EXISTS_IN_GAME ~spwi701.spl~ THEN BEGIN  // greater deflection
- COPY_EXISTING ~spwi701.spl~ ~override~
- LPF ALTER_EFFECT INT_VAR silent = 1 multi_match = 1 match_opcode = 201 STR_VAR resource = ~spwi701b~ END 
- END 
-
-END 
+    ACTION_IF FILE_EXISTS_IN_GAME ~spwi701.spl~ THEN BEGIN  // greater deflection
+        COPY_EXISTING ~spwi701.spl~ ~override~
+        LPF ALTER_EFFECT INT_VAR silent = 1 multi_match = 1 match_opcode = 201 STR_VAR resource = ~spwi701b~ END 
+    END
+END

--- a/spell_rev/lib/kreso_eestatSR.tph
+++ b/spell_rev/lib/kreso_eestatSR.tph
@@ -193,839 +193,585 @@ COPY_EXISTING ~spcl237d.spl~ ~override~ // sun soul monk fireshield
 		resource = EVAL ~%SOURCE_RES%~
 	END
 BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~spcl239a.spl~	override		// sun soul monk blinding attack, assuming fire causes blindness
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~spdd03.spl~	override		// dragon disciple breath attack
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-		COPY_EXISTING	~spctmd01.spl~	override		//fireball
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~spin539.spl~	override		//magma bolt
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
 
-	COPY_EXISTING	~spin160.spl~	override		// salamander fire
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spcl239a.spl~ ~override~ // sun soul monk blinding attack, assuming fire causes blindness
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spin560.spl~	override		// Cinder Shower
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spdd03.spl~ ~override~ // dragon disciple breath attack
+	LPF	ADD_SPELL_EFFECT INT_VAR
+			insert_point = 0
+			opcode = 324
+			target = 2
+			parameter2 = FIRE
+			duration = 1
+		STR_VAR
+			resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spin561.spl~	override		// fire giant lava attack
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spctmd01.spl~ ~override~ //fireball
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-	COPY_EXISTING	~spin567.spl~	override		// mimic fire
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spin539.spl~ ~override~ //magma bolt
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
+COPY_EXISTING ~spin160.spl~ ~override~ // salamander fire
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spin819.spl~	override		// Lava burst
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spin560.spl~ ~override~ // Cinder Shower
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spin885.spl~	override		// kamikaze explosion
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	
-	COPY_EXISTING	~spin894.spl~	override		// Red dragon breath
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spin561.spl~ ~override~ // fire giant lava attack
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spin926.spl~	override		// water jet (fire damage, steam or whatever)
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spin567.spl~ ~override~ // mimic fire
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-	COPY_EXISTING	~spin930.spl~	override		// mephit lava
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spin819.spl~ ~override~ // Lava burst
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spin938.spl~	override		//  Flame fan
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spin885.spl~ ~override~ // kamikaze explosion
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-	COPY_EXISTING	~spin939.spl~	override		//  Flame jet
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spin894.spl~ ~override~ // Red dragon breath
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spin956.spl~	override		//  Hell hound flame breath
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spin926.spl~ ~override~ // water jet (fire damage, steam or whatever)
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spin987.spl~	override		//  Beholder scorcher
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~%sppr116%.spl~	override		//  sunscorch
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-		COPY_EXISTING	~%sppr216%.spl~	override		//  Fire trap
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spin930.spl~ ~override~ // mephit lava
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~sppr503.spl~	override		//  Flamestrike
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spin938.spl~ ~override~ // Flame fan
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-	COPY_EXISTING	~sppr705.spl~	override		//  Firestorm
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spin939.spl~ ~override~ // Flame jet
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
+COPY_EXISTING ~spin956.spl~ ~override~ // Hell hound flame breath
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~sppr730d.spl~	override		//  Flaming death aura
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spin987.spl~ ~override~ // Beholder scorcher
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~sppr952d.spl~	override		//  some fireshield
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~%sppr116%.spl~ ~override~ //Sunscorch
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~sppr985.spl~	override		//  Flamestrike trap
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~spwi001.spl~	override		//  fireball trap
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~%sppr216%.spl~ ~override~ // Fire trap
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
+COPY_EXISTING ~sppr503.spl~ ~override~ // Flamestrike
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spwi022.spl~	override		//  muck(!) trap, fire damage
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~sppr705.spl~ ~override~ // Firestorm
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spwi103.spl~	override		//  burning hands
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~sppr730d.spl~ ~override~ // Flaming death aura
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spwi217.spl~	override		//  Aganaza scorcher
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~sppr952d.spl~ ~override~ // some fireshield
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spwi303.spl~	override		// flame arrow
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~spwi303a.spl~	override		// flame arrow
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~spwi303b.spl~	override		// flame arrow
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~spwi303c.spl~	override		// flame arrow
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~spwi303d.spl~	override		// flame arrow
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY 
-	
-	COPY_EXISTING	~spwi303e.spl~	override		// flame arrow
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~sppr985.spl~ ~override~ // Flamestrike trap
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spwi304.spl~	override		// fireball
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spwi001.spl~ ~override~ // fireball trap
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spwi418d.spl~	override		// fireshield red
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spwi022.spl~ ~override~ // muck(!) trap, fire damage
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spwi523.spl~	override		// sunfire
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~spwi523d.spl~	override		// sunfire
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spwi103.spl~ ~override~ // burning hands
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spwi712.spl~	override		// Delayed blast fireball
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spwi217.spl~ ~override~ // Agannazar scorcher
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spwi810.spl~	override		// incendiary cloud
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~spwi911.spl~	override		// Meteor swarm
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spwi303.spl~ ~override~ // flame arrow
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spwi922.spl~	override		// Dragon's Breath
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spwi303a.spl~ ~override~ // flame arrow
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
+COPY_EXISTING ~spwi303b.spl~ ~override~ // flame arrow
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-	COPY_EXISTING	~spwi940.spl~	override		// Firedrake attack
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spwi303c.spl~ ~override~ // flame arrow
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spwi957.spl~	override		// "RED" Fireball
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spwi303d.spl~ ~override~ // flame arrow
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY 
 
-COPY_EXISTING	~spwi979.spl~	override		// sarevok flamestrike - check if buggy or what
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spwi303e.spl~ ~override~ // flame arrow
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spwish24.spl~	override		// meteor swarm on caster
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	
-COPY_EXISTING	~ohbwi304.spl~	override		// fireball
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spwi304.spl~ ~override~ // fireball
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~spwi418d.spl~ ~override~ // fireshield red
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~spwi523.spl~ ~override~ // sunfire
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~spwi523d.spl~ ~override~ // sunfire
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~spwi712.spl~ ~override~ // Delayed blast fireball
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~spwi810.spl~ ~override~ // incendiary cloud
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~spwi911.spl~ ~override~ // Meteor swarm
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~spwi922.spl~ ~override~ // Dragon's Breath
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~spwi940.spl~ ~override~ // Firedrake attack
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~spwi957.spl~ ~override~ // "RED" Fireball
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~spwi979.spl~	~override~ // sarevok flamestrike - check if buggy or what
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~spwish24.spl~ ~override~ // meteor swarm on caster
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~ohbwi304.spl~ ~override~ // fireball
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
 ////COLD IMMUNITY//
+COPY_EXISTING ~ohbicew.spl~ ~override~ // wall of ice, does crushing as well but assuming it's from cold blocks
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = COLD
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-
-COPY_EXISTING	~ohbicew.spl~	override		// wall of ice, does crushing as well but assuming it's from cold blocks
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = COLD
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~1tarss.spl~	override		// cold fireshield (???)
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = COLD
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~spcryo01.spl~	override		// cryonax cone of cold
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = COLD
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~spcryod.spl~	override		// cryonax fireshield
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = COLD
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-COPY_EXISTING	~spin562.spl~	override		// scalding steam
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = COLD
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-
-	
-	COPY_EXISTING	~spin723.spl~	override		// Dragon rain (cold, can slay but assuming slays by ice)
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = COLD
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~spin833.spl~	override		// Silver dragon cold attack
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = COLD
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~spin936.spl~	override		// Mephit ice shard
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = COLD
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~%sppr418%.spl~	override		// ice storm druid
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = COLD
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-			COPY_EXISTING	~spdr501.spl~	override		// cone of cold avenger
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = COLD
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-
-
-	
-	COPY_EXISTING	~sppr951d.spl~	override		// Fireshield
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = COLD
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~spwi015.spl~	override		// trap cold
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = COLD
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~spwi018.spl~	override		// trap cold
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = COLD
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-		COPY_EXISTING	~%spwi327%.spl~	override		// icelance
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = COLD
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~%sppr326%.spl~	override		// icelance druid
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = COLD
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-
-COPY_EXISTING	~spwi403d.spl~	override		// cold fireshield
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = COLD
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-
-COPY_EXISTING	~spwi404.spl~	override		// ice storm
+COPY_EXISTING ~1tarss.spl~ ~override~ // cold fireshield (???)
 	LPF	ADD_SPELL_EFFECT
 		INT_VAR
 			insert_point = 0
@@ -1038,9 +784,80 @@ COPY_EXISTING	~spwi404.spl~	override		// ice storm
 	END
 BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spwi503.spl~	override		// cone of cold
-	LPF	ADD_SPELL_EFFECT
-		INT_VAR
+COPY_EXISTING ~spcryo01.spl~ ~override~ // cryonax cone of cold
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = COLD
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~spcryod.spl~ ~override~ // cryonax fireshield
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = COLD
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~spin562.spl~ ~override~ // scalding steam
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = COLD
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~spin723.spl~ ~override~ // Dragon rain (cold, can slay but assuming slays by ice)
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = COLD
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~spin833.spl~ ~override~ // Silver dragon cold attack
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = COLD
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~spin936.spl~ ~override~ // Mephit ice shard
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = COLD
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~%sppr418%.spl~ ~override~ // ice storm druid
+	LPF	ADD_SPELL_EFFECT INT_VAR
 			insert_point = 0
 			opcode = 324
 			target = 2
@@ -1051,9 +868,8 @@ COPY_EXISTING	~spwi503.spl~	override		// cone of cold
 	END
 BUT_ONLY IF_EXISTS
 
-COPY_EXISTING ~ubsnobr.spl~ override // snow golem frost ray
-	LPF	ADD_SPELL_EFFECT
-		INT_VAR
+COPY_EXISTING ~spdr501.spl~ ~override~ // cone of cold avenger
+	LPF	ADD_SPELL_EFFECT INT_VAR
 			insert_point = 0
 			opcode = 324
 			target = 2
@@ -1064,9 +880,8 @@ COPY_EXISTING ~ubsnobr.spl~ override // snow golem frost ray
 	END
 BUT_ONLY IF_EXISTS
 
-COPY_EXISTING ~spwi818.spl~ override // icy grasp
-	LPF	ADD_SPELL_EFFECT
-		INT_VAR
+COPY_EXISTING ~sppr951d.spl~ ~override~ // Fireshield
+	LPF	ADD_SPELL_EFFECT INT_VAR
 			insert_point = 0
 			opcode = 324
 			target = 2
@@ -1077,656 +892,704 @@ COPY_EXISTING ~spwi818.spl~ override // icy grasp
 	END
 BUT_ONLY IF_EXISTS
 
-COPY_EXISTING ~spwi818d.spl~ override // icy grasp
-	LPF	ADD_SPELL_EFFECT
-		INT_VAR
-			insert_point = 0
-			opcode = 324
-			target = 2
-			parameter2 = COLD
-			duration = 1
-		STR_VAR
-			resource = EVAL ~%SOURCE_RES%~
+COPY_EXISTING ~spwi015.spl~ ~override~ // trap cold
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = COLD
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
 	END
 BUT_ONLY IF_EXISTS
 
+COPY_EXISTING ~spwi018.spl~ ~override~ // trap cold
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = COLD
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
+COPY_EXISTING ~%spwi327%.spl~ ~override~ // icelance
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = COLD
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~%sppr326%.spl~ ~override~ // icelance druid
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = COLD
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~spwi403d.spl~ ~override~ // cold fireshield
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = COLD
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~spwi404.spl~ ~override~ // ice storm
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = COLD
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~spwi503.spl~ ~override~ // cone of cold
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = COLD
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~ubsnobr.spl~ ~override~ // snow golem frost ray
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = COLD
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~spwi818.spl~ ~override~ // icy grasp
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = COLD
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~spwi818d.spl~ ~override~ // icy grasp
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = COLD
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
 //// ELECTRIC IMMUNITY //
-COPY_EXISTING	~spcl722.spl~	override		// Talos lighting bolt
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ELEC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spcl722.spl~ ~override~ // Talos lighting bolt
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ELEC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spdr301.spl~	override		//  avenger lighting bolt
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ELEC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spdr301.spl~ ~override~ // avenger lighting bolt
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ELEC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spdr601.spl~	override		//  avenger lighting bolt
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ELEC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spdr601.spl~ ~override~ // avenger lighting bolt
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ELEC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spin579.spl~	override		// power amp
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ELEC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-COPY_EXISTING	~spin597.spl~	override		// blue dragon lighting attack
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ELEC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spin579.spl~ ~override~ // power amp
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ELEC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spin714.spl~	override		//  clestial bolt
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ELEC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spin597.spl~ ~override~ // blue dragon lighting attack
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ELEC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spin932.spl~	override		//  mephit lighting bolt
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ELEC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spin714.spl~ ~override~ // celestial bolt
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ELEC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spin933.spl~	override		//  mephit lighting bolt
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ELEC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spin932.spl~ ~override~ // mephit lighting bolt
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ELEC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~sppr302.spl~	override		// call lighting
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ELEC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spin933.spl~ ~override~ // mephit lighting bolt
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ELEC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~sppr304.spl~	override		// glyph of warding
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ELEC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~sppr302.spl~ ~override~ // call lighting
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ELEC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~sppr987.spl~	override		// call lighting trap
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ELEC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~sppr304.spl~ ~override~ // glyph of warding
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ELEC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spwi002.spl~	override		//  lighting trap
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ELEC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~sppr987.spl~ ~override~ // call lighting trap
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ELEC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spwi017.spl~	override		// minor lighting trap
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ELEC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spwi002.spl~ ~override~ // lighting trap
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ELEC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spwi025.spl~	override		// lighting orb
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ELEC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spwi017.spl~	~override~	// minor lighting trap
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ELEC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spwi026.spl~	override		// lighting orb 2
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ELEC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spwi025.spl~ ~override~ // lighting orb
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ELEC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spwi027.spl~	override		// orb 3
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ELEC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spwi026.spl~ ~override~ // lighting orb 2
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ELEC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spwi308.spl~	override		// lighting bolt
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ELEC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spwi027.spl~	~override~ // orb 3
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ELEC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spwi615.spl~	override		// chain lighting
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ELEC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~spwi615a.spl~	override		// chain lighting
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ELEC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~spwi615b.spl~	override		// chain lighting
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ELEC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~bdhalb01.spl~	override		// some halberd from sod
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ELEC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~ohbcalll.spl~	override		// ???
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ELEC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	
-	COPY_EXISTING	~ohbwi308.spl~	override		// lighting bolt
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ELEC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spwi308.spl~ ~override~ // lighting bolt
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ELEC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~spwi615.spl~ ~override~ // chain lighting
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ELEC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~spwi615a.spl~ ~override~ // chain lighting
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ELEC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~spwi615b.spl~ ~override~	// chain lighting
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ELEC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~bdhalb01.spl~ ~override~	// some halberd from sod
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ELEC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~ohbcalll.spl~ ~override~ // ???
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ELEC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~ohbwi308.spl~ ~override~ // lighting bolt
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ELEC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
 ///// ACID IMMUNITY //
+COPY_EXISTING ~ohdmask.spl~ ~override~ // mask attack yea
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ACID
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
+COPY_EXISTING ~ohrgrog.spl~ ~override~ // ??
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ACID
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-	COPY_EXISTING	~ohdmask.spl~	override		// mask attack yea
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ACID
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-		COPY_EXISTING	~ohrgrog.spl~	override		// ??
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ACID
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~bdmepwat.spl~	override		// ???
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ACID
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~spin596.spl~	override		// brown dragon acid breath
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ACID
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~bdmepwat.spl~ ~override~ // ???
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ACID
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spin691.spl~	override		// black dragon breath
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ACID
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-COPY_EXISTING	~spin708.spl~	override		// slime trap
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ACID
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spin596.spl~ ~override~ // brown dragon acid breath
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ACID
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spin913.spl~	override		// Mimic Acid
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ACID
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spin691.spl~ ~override~ // black dragon breath
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ACID
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spin917.spl~	override		// Mane gas
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ACID
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spin708.spl~ ~override~ // slime trap
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ACID
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spwi211.spl~	override		// Acid arrow
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ACID
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~%spwi427%.spl~	override		// vitriolic sphere
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ACID
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~dvwi526d.spl~	override		// mestil
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ACID
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spin913.spl~ ~override~ // Mimic Acid
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ACID
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spwi614.spl~	override		// death fog - it will no longer kill summons acid-immune!
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = ACID
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spin917.spl~ ~override~ // Mane gas
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ACID
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
+COPY_EXISTING ~spwi211.spl~ ~override~ // Acid arrow
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ACID
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~%spwi427%.spl~ ~override~ // vitriolic sphere
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ACID
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~dvwi526d.spl~ ~override~ // mestil
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ACID
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~spwi614.spl~ ~override~ // death fog - it will no longer kill summons acid-immune!
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = ACID
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
 ///  MAGIC DAMAGE IMMUNITY // 
+COPY_EXISTING ~keldorn.spl~ ~override~ // keldorn's armor 
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = MAGIC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
+COPY_EXISTING ~spin202.spl~	~override~ // wounds
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = MAGIC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~keldorn.spl~	override		// keldorn's armor 
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = MAGIC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~spin202.spl~	override		// wounds
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = MAGIC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spin551.spl~ ~override~ // wounds
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = MAGIC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-		COPY_EXISTING	~spin551.spl~	override		// wounds
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = MAGIC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~spin958.spl~	override		// wounds
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = MAGIC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~spin986.spl~	override		// wounds
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = MAGIC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	
-COPY_EXISTING	~spin564.spl~	override		// skull trap exp
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = MAGIC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spin958.spl~ ~override~ // wounds
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = MAGIC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spin912.spl~	override		// psi detonate
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = MAGIC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spin986.spl~ ~override~ // wounds
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = MAGIC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spin962.spl~	override		// beholder magic missile
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = MAGIC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spin564.spl~ ~override~ // skull trap exp
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = MAGIC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~sppr313.spl~	override		// holy  smite
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = MAGIC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~sppr314.spl~	override		// blight
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = MAGIC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spin912.spl~ ~override~ // psi detonate
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = MAGIC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
+COPY_EXISTING ~spin962.spl~ ~override~ // beholder magic missile
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = MAGIC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~sppr612.spl~	override		// bolt of glory
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = MAGIC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~sppr313.spl~ ~override~ // holy  smite
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = MAGIC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
+COPY_EXISTING ~sppr314.spl~ ~override~ // blight
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = MAGIC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~sppr612.spl~ ~override~ // bolt of glory
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = MAGIC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
  
-COPY_EXISTING	~spwi003.spl~	override		// mm trap
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = MAGIC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spwi003.spl~	~override~ // mm trap
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = MAGIC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spwi112.spl~	override		//mm trap
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = MAGIC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spwi112.spl~ ~override~ //mm trap
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = MAGIC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
 //ACTION_IF FILE_EXISTS_IN_GAME ~spwi119a.spl~ THEN BEGIN // This is LMD. AAAAAAAARGH!
 /*COPY_EXISTING ~spwi119a.spl~ ~override~  
@@ -1746,18 +1609,17 @@ LPF ADD_SPELL_EFFECT
 END
 END  */
 
-COPY_EXISTING	~spwi314.spl~	override		// skull trap
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = MAGIC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS 
+COPY_EXISTING ~spwi314.spl~ ~override~ // skull trap
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = MAGIC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS 
 
 //ACTION_IF FILE_EXISTS_IN_GAME ~spwi314.spl~ THEN BEGIN  // Vampiric Touch. AAAAAAAARGH
 /*COPY_EXISTING ~spwi314.spl~ ~override~  
@@ -1777,236 +1639,212 @@ LPF ADD_SPELL_EFFECT
 END
 END */
 
-COPY_EXISTING	~spwi616.spl~	override		// disintegrate
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = MAGIC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spwi616.spl~ ~override~ // disintegrate
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = MAGIC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spwi812.spl~	override		// adhw
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = MAGIC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spwi812.spl~ ~override~ // adhw
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = MAGIC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spwi950.spl~	override		// skull trap
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = MAGIC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spwi950.spl~ ~override~ // skull trap
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = MAGIC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spwi953.spl~	override		// dradael blue firaball
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = MAGIC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spwi953.spl~ ~override~ // dradael blue firaball
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = MAGIC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spwish32.spl~	override		// Wish ADHW
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = MAGIC
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spwish32.spl~ ~override~ // Wish ADHW
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = MAGIC
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
 // POISON IMMUNITY //
+COPY_EXISTING ~bdmucou2.spl~ ~override~ // mucus
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = POISN
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~bdmucou2.spl~	override		// mucus
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = POISN
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~drgrbrht.spl~	override		// poison breath
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = POISN
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~drgrbrht.spl~ ~override~ // poison breath
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = POISN
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-	COPY_EXISTING	~bhaal2b.spl~	override		// poison ability from Ascension
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = POISN
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~bhaal2b.spl~ ~override~ // poison ability from Ascension
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = POISN
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
+COPY_EXISTING ~spin506.spl~ ~override~ // neothelid poison breath
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = POISN
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-	COPY_EXISTING	~spin506.spl~	override		// neothelid poison breath
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = POISN
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-		COPY_EXISTING	~spin568.spl~	override		// mimic poison
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = POISN
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spin568.spl~ ~override~ // mimic poison
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = POISN
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
+COPY_EXISTING ~spin642.spl~ ~override~ // poison cloud
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = POISN
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
+COPY_EXISTING ~spin673.spl~ ~override~ // spore death
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = POISN
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-	COPY_EXISTING	~spin642.spl~	override		// poison cloud
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = POISN
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spin927.spl~ ~override~ // boiling rain storm, stun and poison damage, assume stun is from poison
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = POISN
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-	COPY_EXISTING	~spin673.spl~	override		// spore death
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = POISN
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~sppr411.spl~ ~override~ // priest posion
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = POISN
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-	COPY_EXISTING	~spin927.spl~	override		// boiling rain storm, stun and poison damage, assume stun is from poison
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = POISN
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spwi016.spl~ ~override~ // cloudkill trap
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = POISN
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-	COPY_EXISTING	~sppr411.spl~	override		// priest posion
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = POISN
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-		COPY_EXISTING	~spwi016.spl~	override		// cloudkill trap
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = POISN
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spwi502.spl~ ~override~ // cloudkill
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = POISN
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-
-
-	COPY_EXISTING	~spwi502.spl~	override		// cloudkill
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = POISN
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-
-	COPY_EXISTING	~bdleat05.spl~	override		//   posion backlash?
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = POISN
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~bdleat05.spl~ ~override~ // posion backlash?
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = POISN
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
 /// FREE ACTION //
-
 ACTION_IF FILE_EXISTS_IN_GAME ~bdsha06b.spl~ THEN BEGIN
 COPY_EXISTING ~bdsha06b.spl~ ~override~   // some slow
   LPF ADD_SPELL_EFFECT
@@ -2728,7 +2566,6 @@ END
 END
 
 /// FA PROTECTS VS STUN ON EE//
-
 ACTION_IF FILE_EXISTS_IN_GAME ~sppr718.spl~ THEN BEGIN
 COPY_EXISTING ~sppr718.spl~ ~override~   // 
   LPF ADD_SPELL_EFFECT
@@ -2820,7 +2657,6 @@ END
 END
 
 //// FEAR IMMUNITY //
-
 ACTION_IF FILE_EXISTS_IN_GAME ~bdtgaze.spl~ THEN BEGIN  // terrifying gaze
 COPY_EXISTING ~bdtgaze.spl~ ~override~   
 LPF ADD_SPELL_EFFECT
@@ -3327,7 +3163,6 @@ END
 END
 
 // CHAOS & CONFUSION & CHARM //
-
 ACTION_IF FILE_EXISTS_IN_GAME ~bdblun07.spl~ THEN BEGIN
 COPY_EXISTING ~bdblun07.spl~ ~override~  // ??
 LPF ADD_SPELL_EFFECT
@@ -3906,7 +3741,6 @@ END
 END
 
 /// DEATH IMMUNITY //
-
 ACTION_IF FILE_EXISTS_IN_GAME ~spin681.spl~ THEN BEGIN
 COPY_EXISTING ~spin681.spl~ ~override~   
 LPF ADD_SPELL_EFFECT

--- a/spell_rev/lib/kreso_eestatSR.tph
+++ b/spell_rev/lib/kreso_eestatSR.tph
@@ -13,34 +13,56 @@ OUTER_TEXT_SPRINT spwi327 $new_spell_resrefs(~spwi327~)
 OUTER_TEXT_SPRINT spwi427 $new_spell_resrefs(~spwi427~)
 
 //kjernon's code 
+DEFINE_ACTION_FUNCTION ADD_SPLPROT INT_VAR stat = 0 value = 0 relation = 0 RET new_row BEGIN
+	ACTION_IF (stat > 278)	BEGIN
+		WARN ~SPLPROT.2DA - Stat out of Bounds.~
+	END
+	
+	ACTION_IF ((stat != 259) AND (stat != 260) AND (relation > 11))	BEGIN
+		WARN ~SPLPROT.2DA - Relation out of Bounds.~
+	END
 
-DEFINE_ACTION_FUNCTION	ADD_SPLPROT	INT_VAR	stat = 0	value = 0	relation = 0	RET	new_row		BEGIN
-	ACTION_IF	(stat > 278)	BEGIN	WARN	~SPLPROT.2DA - Stat out of Bounds.~	END
-	ACTION_IF	((stat != 259) AND (stat != 260) AND (relation > 11))	BEGIN	WARN	~SPLPROT.2DA - Relation out of Bounds.~	END
 	COPY_EXISTING ~SPLPROT.2DA~	~override~
-		COUNT_2DA_COLS	cols
+		COUNT_2DA_COLS cols
 		COUNT_2DA_ROWS cols rows
 		TEXT_SPRINT check_row ~~
 		TEXT_SPRINT check_stat ~~
 		SET new_row = 0
-		FOR(current_row = 0; current_row < rows; ++current_row)	BEGIN	READ_2DA_ENTRY current_row 1 cols check_stat
-			PATCH_IF (~%check_stat%~ STRING_EQUAL ~%stat%~)	BEGIN	READ_2DA_ENTRY current_row 2 cols check_value
-				PATCH_IF (~%check_value%~ STRING_EQUAL ~%value%~)	BEGIN	READ_2DA_ENTRY current_row 3 cols check_relation
-					PATCH_IF (~%check_relation%~ STRING_EQUAL ~%relation%~)	BEGIN	new_row = current_row	current_row = rows	END
+		FOR(current_row = 0; current_row < rows; ++current_row)	BEGIN
+			READ_2DA_ENTRY current_row 1 cols check_stat
+			PATCH_IF (~%check_stat%~ STRING_EQUAL ~%stat%~)	BEGIN
+				READ_2DA_ENTRY current_row 2 cols check_value
+				PATCH_IF (~%check_value%~ STRING_EQUAL ~%value%~) BEGIN
+					READ_2DA_ENTRY current_row 3 cols check_relation
+					PATCH_IF (~%check_relation%~ STRING_EQUAL ~%relation%~)	BEGIN
+						new_row = current_row
+						current_row = rows
+					END
 				END
 			END
 		END
-		PATCH_IF (new_row = 0)	BEGIN
-			FOR(current_row = 0; current_row < rows; ++current_row)	BEGIN	READ_2DA_ENTRY current_row 1 cols check_stat
-				PATCH_IF (~%check_stat%~ STRING_EQUAL ~*~)	BEGIN	new_row = current_row	current_row = rows	END
+		PATCH_IF (new_row = 0) BEGIN
+			FOR(current_row = 0; current_row < rows; ++current_row)	BEGIN
+				READ_2DA_ENTRY current_row 1 cols check_stat
+				PATCH_IF (~%check_stat%~ STRING_EQUAL ~*~) BEGIN 
+					new_row = current_row
+					current_row = rows
+				END
 			END
-			PATCH_IF (new_row = 0)	BEGIN	new_row = rows	INSERT_2DA_ROW rows cols ~%new_row%		   %stat%		   %value%		   %relation%~
-			END	ELSE	BEGIN	SET_2DA_ENTRY new_row 1 cols ~%stat%~	SET_2DA_ENTRY new_row 2 cols ~%value%~	SET_2DA_ENTRY new_row 3 cols ~%relation%~	END
+			PATCH_IF (new_row = 0) BEGIN
+				new_row = rows
+				INSERT_2DA_ROW rows cols ~%new_row%	%stat% %value% %relation%~
+			END	ELSE BEGIN
+			 	SET_2DA_ENTRY new_row 1 cols ~%stat%~
+				SET_2DA_ENTRY new_row 2 cols ~%value%~
+				SET_2DA_ENTRY new_row 3 cols ~%relation%~
+			END
 		END
 	BUT_ONLY
 END
-//	Array of Restistance / Stat#
-ACTION_DEFINE_ASSOCIATIVE_ARRAY	DMG_ARRAY	BEGIN
+
+//	Array of Resistance / Stat#
+ACTION_DEFINE_ASSOCIATIVE_ARRAY	DMG_ARRAY BEGIN
 	~CRUSH~		=>	22
 	~ACID~		=>	17
 	~COLD~		=>	15
@@ -54,131 +76,123 @@ ACTION_DEFINE_ASSOCIATIVE_ARRAY	DMG_ARRAY	BEGIN
 	~MFIRE~		=>	19
 	~MCOLD~		=>	20
 END
+
 ACTION_PHP_EACH	DMG_ARRAY AS one => two	BEGIN
-	LAF	ADD_SPLPROT	INT_VAR	stat = two	value = 100	relation = 	2	RET	min = new_row	END
-	LAF	ADD_SPLPROT	INT_VAR	stat = two	value = 128	relation = 	4	RET	max = new_row	END
-	LAF	ADD_SPLPROT	INT_VAR	stat = 260	value = min	relation = 	max	RET	EVAL ~%one%~ = new_row	END
+	LAF	ADD_SPLPROT	INT_VAR	stat = two value = 100 relation = 2 RET min = new_row END
+	LAF	ADD_SPLPROT	INT_VAR	stat = two value = 128 relation = 4	RET	max = new_row END
+	LAF	ADD_SPLPROT	INT_VAR	stat = 260 value = min relation = max RET EVAL ~%one%~ = new_row END
 END
+
 // Sets a variable, named after the string (CRUSH, ACID, COLD, etc..) to the row# to be used for opcode 324/318.  For each spell you would do something like this: // 
 
 // FIRE IMMUNITY//
+COPY_EXISTING ~bdpflame.spl~ ~override~ // produce flame
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+	
+COPY_EXISTING ~bdsha12a.spl~ ~override~ // ??
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+	
+COPY_EXISTING ~bdshld02.spl~ ~override~ // fire attack from shield
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+	
+COPY_EXISTING ~ohbeflam.spl~ ~override~ // flames!
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+		insert_point = 0
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+	
+COPY_EXISTING ~balshld2.spl~ ~override~ // some balthy crp
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-	COPY_EXISTING	~bdpflame.spl~	override		// produce flame
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~bdsha12a.spl~	override		// ??
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~bdshld02.spl~	override		// fire attack from shield
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~ohbeflam.spl~	override		// flames!
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~balshld2.spl~	override		// some balthy crp
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~balth01b.spl~	override		// balthazar fireshield
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~spcl236.spl~	override		// sun soul monk soulray
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~spcl237d.spl~	override		// sun soul monk fireshield
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~balth01b.spl~ ~override~ // balthazar fireshield
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
-COPY_EXISTING	~spcl237d.spl~	override		// sun soul monk fireshield
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = FIRE
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING ~spcl236.spl~ ~override~ // sun soul monk soulray
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~spcl237d.spl~ ~override~ // sun soul monk fireshield
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~spcl237d.spl~ ~override~ // sun soul monk fireshield
+	LPF	ADD_SPELL_EFFECT INT_VAR
+		insert_point = 0
+		opcode = 324
+		target = 2
+		parameter2 = FIRE
+		duration = 1
+	STR_VAR
+		resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 	
 	COPY_EXISTING	~spcl239a.spl~	override		// sun soul monk blinding attack, assuming fire causes blindness
 		LPF	ADD_SPELL_EFFECT
@@ -1011,75 +1025,74 @@ COPY_EXISTING	~spwi403d.spl~	override		// cold fireshield
 		END
 	BUT_ONLY IF_EXISTS
 
-	COPY_EXISTING	~spwi404.spl~	override		// ice storm
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = COLD
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~spwi503.spl~	override		// cone of cold
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = COLD
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-	COPY_EXISTING	~ubsnobr.spl~	override		// snow golem frost ray
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = COLD
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-		COPY_EXISTING	~spwi818.spl~	override		// icy grasp
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = COLD
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
-	
-			COPY_EXISTING	~spwi818d.spl~	override		// icy grasp
-		LPF	ADD_SPELL_EFFECT
-			INT_VAR
-				insert_point = 0
-				opcode = 324
-				target = 2
-				parameter2 = COLD
-				duration = 1
-			STR_VAR
-				resource = EVAL ~%SOURCE_RES%~
-		END
-	BUT_ONLY IF_EXISTS
+COPY_EXISTING	~spwi404.spl~	override		// ice storm
+	LPF	ADD_SPELL_EFFECT
+		INT_VAR
+			insert_point = 0
+			opcode = 324
+			target = 2
+			parameter2 = COLD
+			duration = 1
+		STR_VAR
+			resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING	~spwi503.spl~	override		// cone of cold
+	LPF	ADD_SPELL_EFFECT
+		INT_VAR
+			insert_point = 0
+			opcode = 324
+			target = 2
+			parameter2 = COLD
+			duration = 1
+		STR_VAR
+			resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~ubsnobr.spl~ override // snow golem frost ray
+	LPF	ADD_SPELL_EFFECT
+		INT_VAR
+			insert_point = 0
+			opcode = 324
+			target = 2
+			parameter2 = COLD
+			duration = 1
+		STR_VAR
+			resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~spwi818.spl~ override // icy grasp
+	LPF	ADD_SPELL_EFFECT
+		INT_VAR
+			insert_point = 0
+			opcode = 324
+			target = 2
+			parameter2 = COLD
+			duration = 1
+		STR_VAR
+			resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~spwi818d.spl~ override // icy grasp
+	LPF	ADD_SPELL_EFFECT
+		INT_VAR
+			insert_point = 0
+			opcode = 324
+			target = 2
+			parameter2 = COLD
+			duration = 1
+		STR_VAR
+			resource = EVAL ~%SOURCE_RES%~
+	END
+BUT_ONLY IF_EXISTS
 
 
 
 //// ELECTRIC IMMUNITY //
-
 COPY_EXISTING	~spcl722.spl~	override		// Talos lighting bolt
 		LPF	ADD_SPELL_EFFECT
 			INT_VAR

--- a/spell_rev/lib/kreso_haste_slow.tph
+++ b/spell_rev/lib/kreso_haste_slow.tph
@@ -9,227 +9,220 @@ ADD_SECTYPE ~k1#Slow~ @21004  // string to counter Slow - "Slow Dispelled" or si
   //// GLOBAL PATCH ///
   
 COPY_EXISTING_REGEXP GLOB ~^.+\.itm$~ ~override~  // slowing items are countered by Haste
-  PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
-    READ_LONG 0x64 ab_off
-    READ_SHORT 0x68 ab_num
-    READ_LONG 0x6a ef_off
-    FOR (i=0;i<ab_num;i+=1) BEGIN
-      READ_SHORT (ab_off+i*0x38+0x1e) ef_num
-      READ_SHORT (ab_off+i*0x38+0x20) ef_ind
-      FOR (k=0;k<ef_num;k+=1) BEGIN
-        READ_SHORT (ef_off+(ef_ind+k)*0x30) opcode
-        PATCH_IF opcode=40 BEGIN
-		WRITE_BYTE 0x8B "%k1#Slow%" 
-END
-END
-END
-END
+    PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
+        READ_LONG 0x64 ab_off
+        READ_SHORT 0x68 ab_num
+        READ_LONG 0x6a ef_off
+        FOR (i=0;i<ab_num;i+=1) BEGIN
+            READ_SHORT (ab_off+i*0x38+0x1e) ef_num
+            READ_SHORT (ab_off+i*0x38+0x20) ef_ind
+            FOR (k=0;k<ef_num;k+=1) BEGIN
+                READ_SHORT (ef_off+(ef_ind+k)*0x30) opcode
+                PATCH_IF opcode=40 BEGIN
+		                WRITE_BYTE 0x8B "%k1#Slow%" 
+                END
+            END
+        END
+    END
 BUT_ONLY
 
 COPY_EXISTING_REGEXP GLOB ~^.+\.itm$~ ~override~ 
-  PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
-    READ_LONG 0x64 ab_off
-    READ_SHORT 0x68 ab_num
-    READ_LONG 0x6a ef_off
-    FOR (i=0;i<ab_num;i+=1) BEGIN
-      READ_SHORT (ab_off+i*0x38+0x1e) ef_num
-      READ_SHORT (ab_off+i*0x38+0x20) ef_ind
-      FOR (k=0;k<ef_num;k+=1) BEGIN
-        READ_SHORT (ef_off+(ef_ind+k)*0x30) opcode
-        PATCH_IF opcode=16 BEGIN
-		WRITE_BYTE 0x8B "%k1#Haste%" 
-END
-END
-END
-END
-BUT_ONLY
-
-COPY_EXISTING_REGEXP GLOB ~^.+\.spl$~ ~override~
-  PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
-    SET found_haste=0
-    READ_LONG 0x64 ab_off
-    READ_SHORT 0x68 ab_num
-    READ_LONG 0x6a ef_off
-    FOR (i=0;i<ab_num;i+=1) BEGIN
-      READ_SHORT (ab_off+i*0x28+0x1e) ef_num
-      READ_SHORT (ab_off+i*0x28+0x20) ef_ind
-      FOR (k=0;k<ef_num;k+=1) BEGIN
-        READ_SHORT (ef_off+(k+ef_ind)*0x30) opcode
-        PATCH_IF opcode=16 BEGIN
-          SET found_haste=1
-          PATCH_IF found_haste=1 BEGIN
-		  WRITE_BYTE 0x27 "%k1#Haste%"
-		  END
-		 END
-      END
-	END
-	END
-BUT_ONLY
-
-COPY_EXISTING_REGEXP GLOB ~^.+\.spl$~ ~override~
-  PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
-    SET found_slow=0
-    READ_LONG 0x64 ab_off
-    READ_SHORT 0x68 ab_num
-    READ_LONG 0x6a ef_off
-    FOR (i=0;i<ab_num;i+=1) BEGIN
-      READ_SHORT (ab_off+i*0x28+0x1e) ef_num
-      READ_SHORT (ab_off+i*0x28+0x20) ef_ind
-      FOR (k=0;k<ef_num;k+=1) BEGIN
-        READ_SHORT (ef_off+(k+ef_ind)*0x30) opcode
-        PATCH_IF opcode=40 BEGIN
-          SET found_slow=1
-          PATCH_IF found_slow=1 BEGIN
-		  WRITE_BYTE 0x27 "%k1#Slow%"
-		  END
-		 END
-      END
-	END
-	END
-BUT_ONLY
- 
-COPY_EXISTING_REGEXP GLOB ~.*\.itm$~ ~override~
-PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
-LPF CLONE_EFFECT INT_VAR match_opcode = 40 opcode = 221 parameter1 = 9 parameter2 = %k1#Haste% savingthrow = 0 silent = 1 END
-END
-BUT_ONLY
-
-COPY_EXISTING_REGEXP GLOB ~.*\.itm$~ ~override~
-PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
-LPF CLONE_EFFECT INT_VAR match_opcode = 16 opcode = 221 parameter1 = 9 parameter2 = %k1#Slow% savingthrow = 0 silent = 1 END
-END
-BUT_ONLY
-
- COPY_EXISTING_REGEXP GLOB ~.*\.spl$~ ~override~
- PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
- LPF CLONE_EFFECT INT_VAR match_opcode = 16 opcode = 221 parameter1 = 9 parameter2 = %k1#Slow% savingthrow = 0 silent = 1 END
- END
- BUT_ONLY
- 
- COPY_EXISTING_REGEXP GLOB ~.*\.spl$~ ~override~
- PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
- LPF CLONE_EFFECT INT_VAR match_opcode = 40 opcode = 221 parameter1 = 9 parameter2 = %k1#Haste% savingthrow = 0 silent = 1 END
- END
- BUT_ONLY
-  
-  // SR spells don't use Haste opcode so are handled seperately //
-  
- COPY_EXISTING ~spwi305.spl~ ~override~    // Wizard Haste
-  WRITE_BYTE 0x27 "%k1#Haste%"  
-  LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 221 END
-  LPF ADD_SPELL_EFFECT
-	INT_VAR
-	opcode			= 221
-	target			= 2
-	power			= 3
-	savingthrow     = 0
-	parameter1		= 9
-	parameter2		= EVALUATE_BUFFER %k1#Slow%
-	timing			= 1
-	insert_point    = 1
+    PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
+        READ_LONG 0x64 ab_off
+        READ_SHORT 0x68 ab_num
+        READ_LONG 0x6a ef_off
+        FOR (i=0;i<ab_num;i+=1) BEGIN
+            READ_SHORT (ab_off+i*0x38+0x1e) ef_num
+            READ_SHORT (ab_off+i*0x38+0x20) ef_ind
+            FOR (k=0;k<ef_num;k+=1) BEGIN
+                READ_SHORT (ef_off+(ef_ind+k)*0x30) opcode
+                PATCH_IF opcode=16 BEGIN
+		                WRITE_BYTE 0x8B "%k1#Haste%" 
+                END
+            END
+        END
     END
-  BUT_ONLY 
+BUT_ONLY
+
+COPY_EXISTING_REGEXP GLOB ~^.+\.spl$~ ~override~
+    PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
+        SET found_haste=0
+        READ_LONG 0x64 ab_off
+        READ_SHORT 0x68 ab_num
+        READ_LONG 0x6a ef_off
+        FOR (i=0;i<ab_num;i+=1) BEGIN
+            READ_SHORT (ab_off+i*0x28+0x1e) ef_num
+            READ_SHORT (ab_off+i*0x28+0x20) ef_ind
+            FOR (k=0;k<ef_num;k+=1) BEGIN
+                READ_SHORT (ef_off+(k+ef_ind)*0x30) opcode
+                PATCH_IF opcode=16 BEGIN
+                    SET found_haste=1
+                    PATCH_IF found_haste=1 BEGIN
+		                    WRITE_BYTE 0x27 "%k1#Haste%"
+		                END
+		            END
+            END
+	      END
+	  END
+BUT_ONLY
+
+COPY_EXISTING_REGEXP GLOB ~^.+\.spl$~ ~override~
+    PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
+        SET found_slow=0
+        READ_LONG 0x64 ab_off
+        READ_SHORT 0x68 ab_num
+        READ_LONG 0x6a ef_off
+        FOR (i=0;i<ab_num;i+=1) BEGIN
+            READ_SHORT (ab_off+i*0x28+0x1e) ef_num
+            READ_SHORT (ab_off+i*0x28+0x20) ef_ind
+            FOR (k=0;k<ef_num;k+=1) BEGIN
+                READ_SHORT (ef_off+(k+ef_ind)*0x30) opcode
+                PATCH_IF opcode=40 BEGIN
+                    SET found_slow=1
+                    PATCH_IF found_slow=1 BEGIN
+		                    WRITE_BYTE 0x27 "%k1#Slow%"
+		                END
+		            END
+            END
+	      END
+	  END
+BUT_ONLY
+ 
+COPY_EXISTING_REGEXP GLOB ~.*\.itm$~ ~override~
+    PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
+        LPF CLONE_EFFECT INT_VAR match_opcode = 40 opcode = 221 parameter1 = 9 parameter2 = %k1#Haste% savingthrow = 0 silent = 1 END
+    END
+BUT_ONLY
+
+COPY_EXISTING_REGEXP GLOB ~.*\.itm$~ ~override~
+    PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
+        LPF CLONE_EFFECT INT_VAR match_opcode = 16 opcode = 221 parameter1 = 9 parameter2 = %k1#Slow% savingthrow = 0 silent = 1 END
+    END
+BUT_ONLY
+
+ COPY_EXISTING_REGEXP GLOB ~.*\.spl$~ ~override~
+    PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
+        LPF CLONE_EFFECT INT_VAR match_opcode = 16 opcode = 221 parameter1 = 9 parameter2 = %k1#Slow% savingthrow = 0 silent = 1 END
+    END
+ BUT_ONLY
+ 
+ COPY_EXISTING_REGEXP GLOB ~.*\.spl$~ ~override~
+    PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
+        LPF CLONE_EFFECT INT_VAR match_opcode = 40 opcode = 221 parameter1 = 9 parameter2 = %k1#Haste% savingthrow = 0 silent = 1 END
+    END
+ BUT_ONLY
   
-ACTION_IF  FILE_EXISTS_IN_GAME ~potn14.spl~ BEGIN // IR Oil of Speed - commented out for now, shouldn't remove slow
+// SR spells don't use Haste opcode so are handled seperately //
+COPY_EXISTING ~spwi305.spl~ ~override~    // Wizard Haste
+    WRITE_BYTE 0x27 "%k1#Haste%"  
+    LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 221 END
+    LPF ADD_SPELL_EFFECT INT_VAR
+        opcode = 221
+        target = 2
+        power = 3
+        savingthrow = 0
+        parameter1 = 9
+        parameter2 = EVALUATE_BUFFER "%k1#Slow%"
+        timing = 1
+        insert_point = 1
+    END
+BUT_ONLY 
+    
+ACTION_IF  FILE_EXISTS_IN_GAME ~potn14.spl~ BEGIN
+// IR Oil of Speed - commented out for now, shouldn't remove slow
 // EDIT by SD: why not? I say uncomment this for now, unless there is good reason to exempt potions of speed
-COPY_EXISTING ~potn14.spl~ ~override~  
- LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 221 header = 0 END
- WRITE_BYTE 0x27 "%k1#Haste%"
-  LPF ADD_SPELL_EFFECT
-	INT_VAR
-	opcode			= 221
-	target			= 2
-	power			= 3
-	parameter1		= 9
-	savingthrow     = 0
-	parameter2		= EVALUATE_BUFFER %k1#Slow%
-	timing			= 1
-	insert_point    = 1
-    END
-  BUT_ONLY
+    COPY_EXISTING ~potn14.spl~ ~override~  
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 221 header = 0 END
+        WRITE_BYTE 0x27 "%k1#Haste%"
+        LPF ADD_SPELL_EFFECT INT_VAR
+            opcode = 221
+            target = 2
+            power = 3
+            parameter1 = 9
+            savingthrow = 0
+            parameter2 = EVALUATE_BUFFER "%k1#Slow%"
+            timing = 1
+            insert_point = 1
+        END
+    BUT_ONLY
 END   
   
 // these next two are from Bartimaeus' IRR... included for compatibility
 ACTION_IF (FILE_EXISTS_IN_GAME ~sw1h27.spl~) THEN BEGIN // Arbane's Sword
- COPY_EXISTING ~sw1h27.spl~ ~override~
-  WRITE_BYTE 0x27 "%k1#Haste%"
-  LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 221 END
-  LPF ADD_SPELL_EFFECT
-	INT_VAR
-	opcode			= 221
-	target			= 2
-	power			= 3
-	savingthrow     = 0
-	parameter1		= 9
-	parameter2		= EVALUATE_BUFFER %k1#Slow%
-	timing			= 1
-	insert_point    = 1
-    END
-  BUT_ONLY
+    COPY_EXISTING ~sw1h27.spl~ ~override~
+        WRITE_BYTE 0x27 "%k1#Haste%"
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 221 END
+        LPF ADD_SPELL_EFFECT INT_VAR
+            opcode = 221
+            target = 2
+            power	= 3
+            savingthrow = 0
+            parameter1 = 9
+            parameter2 = EVALUATE_BUFFER "%k1#Slow%"
+            timing = 1
+            insert_point = 1
+        END
+    BUT_ONLY
 END
   
 ACTION_IF (FILE_EXISTS_IN_GAME ~dvhaste.spl~) THEN BEGIN // Haste
- COPY_EXISTING ~dvhaste.spl~ ~override~
-  WRITE_BYTE 0x27 "%k1#Haste%"
-  LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 221 END
-  LPF ADD_SPELL_EFFECT
-	INT_VAR
-	opcode			= 221
-	target			= 2
-	power			= 3
-	savingthrow     = 0
-	parameter1		= 9
-	parameter2		= EVALUATE_BUFFER %k1#Slow%
-	timing			= 1
-	insert_point    = 1
-    END
-  BUT_ONLY
+    COPY_EXISTING ~dvhaste.spl~ ~override~
+        WRITE_BYTE 0x27 "%k1#Haste%"
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 221 END
+        LPF ADD_SPELL_EFFECT INT_VAR
+            opcode = 221
+            target = 2
+            power	= 3
+            savingthrow = 0
+            parameter1 = 9
+            parameter2 = EVALUATE_BUFFER "%k1#Slow%"
+            timing = 1
+            insert_point = 1
+        END
+    BUT_ONLY
 END
 
 COPY_EXISTING ~spwi613.spl~ ~override~    // Wizard Imp.Haste  - no sectype change since it's slow-immune
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 221 END
-  LPF ADD_SPELL_EFFECT
-	INT_VAR
-	opcode			= 221
-	target			= 2
-	power			= 6
-	parameter1		= 9
-	parameter2		= EVALUATE_BUFFER %k1#Slow%
-	timing			= 1
-	insert_point    = 1
-END
+    LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 221 END
+    LPF ADD_SPELL_EFFECT INT_VAR
+        opcode = 221
+        target = 2
+        power	= 6
+        parameter1 = 9
+        parameter2 = EVALUATE_BUFFER "%k1#Slow%"
+        timing = 1
+        insert_point = 1
+    END
 BUT_ONLY 
 
 COPY_EXISTING ~spra301.spl~ ~override~    // stalker Haste
-  WRITE_BYTE 0x27 "%k1#Haste%"  
-  LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 221 END
-  LPF ADD_SPELL_EFFECT
-	INT_VAR
-	opcode			= 221
-	target			= 2
-	power			= 3
-	savingthrow     = 0
-	parameter1		= 9
-	parameter2		= EVALUATE_BUFFER %k1#Slow%
-	timing			= 1
-	insert_point    = 1
+    WRITE_BYTE 0x27 "%k1#Haste%"
+    LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 221 END
+    LPF ADD_SPELL_EFFECT INT_VAR
+        opcode = 221
+        target = 2
+        power = 3
+        savingthrow = 0
+        parameter1 = 9
+        parameter2 = EVALUATE_BUFFER "%k1#Slow%"
+        timing = 1
+        insert_point = 1
     END
 BUT_ONLY 
 
-ACTION_IF  FILE_EXISTS_IN_GAME ~spin828.spl~ BEGIN
-  COPY_EXISTING ~spin828.spl~ ~override~    // stalker Haste
-  WRITE_BYTE 0x27 "%k1#Haste%"  
-  LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 221 END
-  LPF ADD_SPELL_EFFECT
-	INT_VAR
-	opcode			= 221
-	target			= 1
-	power			= 0
-	savingthrow     = 0
-	parameter1		= 9
-	parameter2		= EVALUATE_BUFFER %k1#Slow%
-	timing			= 1
-	insert_point    = 1
-    END
-  BUT_ONLY 
+ACTION_IF FILE_EXISTS_IN_GAME ~spin828.spl~ BEGIN
+    COPY_EXISTING ~spin828.spl~ ~override~    // stalker Haste
+        WRITE_BYTE 0x27 "%k1#Haste%"  
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 221 END
+        LPF ADD_SPELL_EFFECT INT_VAR
+            opcode = 221
+            target = 1
+            power = 0
+            savingthrow = 0
+            parameter1 = 9
+            parameter2 = EVALUATE_BUFFER "%k1#Slow%"
+            timing = 1
+            insert_point = 1
+        END
+    BUT_ONLY 
 END

--- a/spell_rev/lib/kreso_hla.tph
+++ b/spell_rev/lib/kreso_hla.tph
@@ -1,52 +1,54 @@
-ACTION_IF  FILE_EXISTS_IN_GAME ~spcl900.spl~ BEGIN                     // whirlwind
-COPY_EXISTING ~spcl900.spl~ ~override~
-SAY NAME1 @10003    SAY UNIDENTIFIED_DESC @10004
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 1 END
-LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 142 duration = 12 END
-LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 73 duration = 12 END 
-LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 54 duration = 12 END
-LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 317 duration = 12 END 
-LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 174 match_timing = 3 duration = 12 END
+ACTION_IF FILE_EXISTS_IN_GAME ~spcl900.spl~ BEGIN // whirlwind
+    COPY_EXISTING ~spcl900.spl~ ~override~
+        SAY NAME1 @10003
+        SAY UNIDENTIFIED_DESC @10004
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 1 END
+        LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 142 duration = 12 END
+        LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 73 duration = 12 END 
+        LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 54 duration = 12 END
+        LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 317 duration = 12 END 
+        LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 174 match_timing = 3 duration = 12 END
 END
 
 
-ACTION_IF  FILE_EXISTS_IN_GAME ~spcl900.spl~ BEGIN                     // g whirlwind
-COPY_EXISTING ~spcl901.spl~ ~override~
-SAY NAME1 @10005    SAY UNIDENTIFIED_DESC @10006
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 1 END
-LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 142 duration = 12 END
-LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 317 duration = 12 END 
-LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 174 match_timing = 3 duration = 12 END
+ACTION_IF FILE_EXISTS_IN_GAME ~spcl900.spl~ BEGIN // greater whirlwind
+    COPY_EXISTING ~spcl901.spl~ ~override~
+        SAY NAME1 @10005
+        SAY UNIDENTIFIED_DESC @10006
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 1 END
+        LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 142 duration = 12 END
+        LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 317 duration = 12 END 
+        LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 174 match_timing = 3 duration = 12 END
 END
 
-ACTION_IF  FILE_EXISTS_IN_GAME ~spcl907.spl~ BEGIN                     // hardiness
-COPY_EXISTING ~spcl907.spl~ ~override~
-SAY NAME1 @10001    SAY UNIDENTIFIED_DESC @10002
-LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 86 parameter1 = 20 END
-LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 87 parameter1 = 20 END
-LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 88 parameter1 = 20 END
-LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 89 parameter1 = 20 END
-LPF CLONE_EFFECT INT_VAR match_opcode = 86 opcode = 27 parameter2 = 0 END
-LPF CLONE_EFFECT INT_VAR match_opcode = 86 opcode = 28 parameter2 = 0 END
-LPF CLONE_EFFECT INT_VAR match_opcode = 86 opcode = 29 parameter2 = 0 END
-LPF CLONE_EFFECT INT_VAR match_opcode = 86 opcode = 30 parameter2 = 0 END
-LPF CLONE_EFFECT INT_VAR match_opcode = 86 opcode = 31 parameter2 = 0 END
-LPF CLONE_EFFECT INT_VAR match_opcode = 86 opcode = 84 parameter2 = 0 END
-LPF CLONE_EFFECT INT_VAR match_opcode = 86 opcode = 85 parameter2 = 0 END
+ACTION_IF FILE_EXISTS_IN_GAME ~spcl907.spl~ BEGIN // hardiness
+    COPY_EXISTING ~spcl907.spl~ ~override~
+        SAY NAME1 @10001
+        SAY UNIDENTIFIED_DESC @10002
+        LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 86 parameter1 = 20 END
+        LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 87 parameter1 = 20 END
+        LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 88 parameter1 = 20 END
+        LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 89 parameter1 = 20 END
+        LPF CLONE_EFFECT INT_VAR match_opcode = 86 opcode = 27 parameter2 = 0 END
+        LPF CLONE_EFFECT INT_VAR match_opcode = 86 opcode = 28 parameter2 = 0 END
+        LPF CLONE_EFFECT INT_VAR match_opcode = 86 opcode = 29 parameter2 = 0 END
+        LPF CLONE_EFFECT INT_VAR match_opcode = 86 opcode = 30 parameter2 = 0 END
+        LPF CLONE_EFFECT INT_VAR match_opcode = 86 opcode = 31 parameter2 = 0 END
+        LPF CLONE_EFFECT INT_VAR match_opcode = 86 opcode = 84 parameter2 = 0 END
+        LPF CLONE_EFFECT INT_VAR match_opcode = 86 opcode = 85 parameter2 = 0 END
 END
 
-
-ACTION_IF  FILE_EXISTS_IN_GAME ~spwish12.spl~ BEGIN                     // hardiness wish
-COPY_EXISTING ~spwish12.spl~ ~override~
-LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 86 parameter1 = 20 END
-LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 87 parameter1 = 20 END
-LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 88 parameter1 = 20 END
-LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 89 parameter1 = 20 END
-LPF CLONE_EFFECT INT_VAR match_opcode = 86 opcode = 27 parameter2 = 0 END
-LPF CLONE_EFFECT INT_VAR match_opcode = 86 opcode = 28 parameter2 = 0 END
-LPF CLONE_EFFECT INT_VAR match_opcode = 86 opcode = 29 parameter2 = 0 END
-LPF CLONE_EFFECT INT_VAR match_opcode = 86 opcode = 30 parameter2 = 0 END
-LPF CLONE_EFFECT INT_VAR match_opcode = 86 opcode = 31 parameter2 = 0 END
-LPF CLONE_EFFECT INT_VAR match_opcode = 86 opcode = 84 parameter2 = 0 END
-LPF CLONE_EFFECT INT_VAR match_opcode = 86 opcode = 85 parameter2 = 0 END
+ACTION_IF FILE_EXISTS_IN_GAME ~spwish12.spl~ BEGIN // hardiness wish
+    COPY_EXISTING ~spwish12.spl~ ~override~
+        LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 86 parameter1 = 20 END
+        LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 87 parameter1 = 20 END
+        LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 88 parameter1 = 20 END
+        LPF ALTER_SPELL_EFFECT INT_VAR match_opcode = 89 parameter1 = 20 END
+        LPF CLONE_EFFECT INT_VAR match_opcode = 86 opcode = 27 parameter2 = 0 END
+        LPF CLONE_EFFECT INT_VAR match_opcode = 86 opcode = 28 parameter2 = 0 END
+        LPF CLONE_EFFECT INT_VAR match_opcode = 86 opcode = 29 parameter2 = 0 END
+        LPF CLONE_EFFECT INT_VAR match_opcode = 86 opcode = 30 parameter2 = 0 END
+        LPF CLONE_EFFECT INT_VAR match_opcode = 86 opcode = 31 parameter2 = 0 END
+        LPF CLONE_EFFECT INT_VAR match_opcode = 86 opcode = 84 parameter2 = 0 END
+        LPF CLONE_EFFECT INT_VAR match_opcode = 86 opcode = 85 parameter2 = 0 END
 END

--- a/spell_rev/lib/kreso_petrification.tph
+++ b/spell_rev/lib/kreso_petrification.tph
@@ -1,115 +1,191 @@
-/////PETRIFICATION/// 
-
-
-
- ADD_SECTYPE ~k1#Petrify~ @21005  // string to counter Petrify - "Petrification effect removed", whatever
+/////PETRIFICATION///
+ADD_SECTYPE ~k1#Petrify~ @21005  // string to counter Petrify - "Petrification effect removed", whatever
   
-  //// GLOBAL PATCH ///
-  
+//// GLOBAL PATCH ///
 COPY_EXISTING_REGEXP GLOB ~^.+\.itm$~ ~override~  
-  PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
-    READ_LONG 0x64 ab_off
-    READ_SHORT 0x68 ab_num
-    READ_LONG 0x6a ef_off
-    FOR (i=0;i<ab_num;i+=1) BEGIN
-      READ_SHORT (ab_off+i*0x38+0x1e) ef_num
-      READ_SHORT (ab_off+i*0x38+0x20) ef_ind
-      FOR (k=0;k<ef_num;k+=1) BEGIN
-        READ_SHORT (ef_off+(ef_ind+k)*0x30) opcode
-        PATCH_IF opcode=134 BEGIN
-		WRITE_BYTE 0x8B "%k1#Petrify%" 
-LPF CLONE_EFFECT INT_VAR match_opcode = 134 opcode = 126 timing = 0 parameter1 = 50 parameter2 = 2  timing = 0 duration = 18 savingthrow = 0 silent = 1 END 
-LPF CLONE_EFFECT INT_VAR match_opcode = 134 opcode = 141 timing = 0 duration = 0 savingthrow = 0  silent = 1 END
-LPF CLONE_EFFECT INT_VAR match_opcode = 134 opcode = 142 timing = 0 duration = 0 parameter1 = 41 savingthrow = 0 silent = 1  END
-LPF CLONE_EFFECT INT_VAR match_opcode = 134 opcode = 139 timing = 0 duration = 0 savingthrow = 0 parameter1 = 14668  silent = 1 END
-LPF CLONE_EFFECT INT_VAR match_opcode = 134 opcode = 146 parameter2 = 1 timing = 4 duration = 6 savingthrow = 0 STR_VAR resource = spwi604d  silent = 1 END
-END
-
-END
-END END
+    PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
+        READ_LONG 0x64 ab_off
+        READ_SHORT 0x68 ab_num
+        READ_LONG 0x6a ef_off
+        FOR (i=0;i<ab_num;i+=1) BEGIN
+            READ_SHORT (ab_off+i*0x38+0x1e) ef_num
+            READ_SHORT (ab_off+i*0x38+0x20) ef_ind
+            FOR (k=0;k<ef_num;k+=1) BEGIN
+                READ_SHORT (ef_off+(ef_ind+k)*0x30) opcode
+                PATCH_IF opcode=134 BEGIN
+	  	              WRITE_BYTE 0x8B "%k1#Petrify%" 
+                    LPF CLONE_EFFECT INT_VAR
+                        match_opcode = 134
+                        opcode = 126
+                        timing = 0
+                        parameter1 = 50
+                        parameter2 = 2
+                        timing = 0
+                        duration = 18
+                        savingthrow = 0
+                        silent = 1
+                    END 
+                    LPF CLONE_EFFECT INT_VAR
+                        match_opcode = 134
+                        opcode = 141
+                        timing = 0
+                        duration = 0
+                        savingthrow = 0
+                        silent = 1
+                    END
+                    LPF CLONE_EFFECT INT_VAR
+                        match_opcode = 134
+                        opcode = 142
+                        timing = 0
+                        duration = 0
+                        parameter1 = 41
+                        savingthrow = 0
+                        silent = 1
+                    END
+                    LPF CLONE_EFFECT INT_VAR
+                        match_opcode = 134
+                        opcode = 139
+                        timing = 0
+                        duration = 0
+                        savingthrow = 0
+                        parameter1 = 14668
+                        silent = 1
+                    END
+                    LPF CLONE_EFFECT INT_VAR
+                        match_opcode = 134
+                        opcode = 146
+                        parameter2 = 1
+                        timing = 4
+                        duration = 6
+                        savingthrow = 0
+                        silent = 1
+                    STR_VAR
+                        resource = "spwi604d"
+                    END
+                END
+            END
+        END
+    END
 BUT_ONLY
 
-
-
 COPY_EXISTING_REGEXP GLOB ~^.+\.spl$~ ~override~
-  PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
-    SET found_petrify=0
-    READ_LONG 0x64 ab_off
-    READ_SHORT 0x68 ab_num
-    READ_LONG 0x6a ef_off
-    FOR (i=0;i<ab_num;i+=1) BEGIN
-      READ_SHORT (ab_off+i*0x28+0x1e) ef_num
-      READ_SHORT (ab_off+i*0x28+0x20) ef_ind
-      FOR (k=0;k<ef_num;k+=1) BEGIN
-        READ_SHORT (ef_off+(k+ef_ind)*0x30) opcode
-        PATCH_IF opcode=134 BEGIN
-          SET found_petrify=1
-          PATCH_IF found_petrify=1 BEGIN
-		  WRITE_BYTE 0x27 "%k1#Petrify%" 
-LPF CLONE_EFFECT INT_VAR match_opcode = 134 opcode = 126 timing = 0 parameter1 = 50 parameter2 = 2 duration = 18 savingthrow = 0 silent = 1 END
-LPF CLONE_EFFECT INT_VAR match_opcode = 134 opcode = 141 timing = 0 duration = 0 savingthrow = 0  silent = 1 END
-LPF CLONE_EFFECT INT_VAR match_opcode = 134 opcode = 142 timing = 0 duration = 0 parameter2 = 41 savingthrow = 0 silent = 1  END
-LPF CLONE_EFFECT INT_VAR match_opcode = 134 opcode = 139 timing = 0 duration = 0 savingthrow = 0 parameter1 = 14668  silent = 1 END
-LPF CLONE_EFFECT INT_VAR match_opcode = 134 opcode = 146 timing = 4 duration = 6 savingthrow = 0 parameter2 = 1 STR_VAR resource = spwi604d  silent = 1 END
-END
-END
-END
-END
-END
+    PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
+        SET found_petrify=0
+        READ_LONG 0x64 ab_off
+        READ_SHORT 0x68 ab_num
+        READ_LONG 0x6a ef_off
+        FOR (i=0;i<ab_num;i+=1) BEGIN
+            READ_SHORT (ab_off+i*0x28+0x1e) ef_num
+            READ_SHORT (ab_off+i*0x28+0x20) ef_ind
+            FOR (k=0;k<ef_num;k+=1) BEGIN
+                READ_SHORT (ef_off+(k+ef_ind)*0x30) opcode
+                PATCH_IF opcode=134 BEGIN
+                    SET found_petrify=1
+                    PATCH_IF found_petrify=1 BEGIN
+                        WRITE_BYTE 0x27 "%k1#Petrify%" 
+                        LPF CLONE_EFFECT INT_VAR
+                            match_opcode = 134
+                            opcode = 126
+                            timing = 0
+                            parameter1 = 50
+                            parameter2 = 2
+                            duration = 18
+                            savingthrow = 0
+                            silent = 1
+                        END
+                        LPF CLONE_EFFECT INT_VAR
+                            match_opcode = 134
+                            opcode = 141
+                            timing = 0
+                            duration = 0
+                            savingthrow = 0
+                            silent = 1
+                        END
+                        LPF CLONE_EFFECT INT_VAR
+                            match_opcode = 134
+                            opcode = 142
+                            timing = 0
+                            duration = 0
+                            parameter2 = 41
+                            savingthrow = 0
+                            silent = 1
+                        END
+                        LPF CLONE_EFFECT INT_VAR
+                            match_opcode = 134
+                            opcode = 139
+                            timing = 0
+                            duration = 0
+                            savingthrow = 0
+                            parameter1 = 14668
+                            silent = 1
+                        END
+                        LPF CLONE_EFFECT INT_VAR
+                            match_opcode = 134
+                            opcode = 146
+                            timing = 4
+                            duration = 6
+                            savingthrow = 0
+                            parameter2 = 1
+                            silent = 1
+                        STR_VAR
+                            resource = "spwi604d"
+                        END
+                    END
+                END
+            END
+        END
+    END
 BUT_ONLY 
  
 
- /// all items/spells using Flesh to Stone remove sectype
- 
+/// all items/spells using Flesh to Stone remove sectype
 COPY_EXISTING_REGEXP GLOB ~.*\.itm$~ ~override~
-PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
-LPF CLONE_EFFECT INT_VAR match_opcode = 43 opcode = 221  parameter2 = %k1#Petrify% silent = 1 END
-END
+    PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
+        LPF CLONE_EFFECT INT_VAR match_opcode = 43 opcode = 221  parameter2 = %k1#Petrify% silent = 1 END
+    END
 BUT_ONLY
 
- COPY_EXISTING_REGEXP GLOB ~.*\.spl$~ ~override~
- PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
- LPF CLONE_EFFECT INT_VAR match_opcode = 43 opcode = 221  parameter2 = %k1#Petrify% silent = 1 END
- END
- BUT_ONLY
+COPY_EXISTING_REGEXP GLOB ~.*\.spl$~ ~override~
+    PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
+        LPF CLONE_EFFECT INT_VAR match_opcode = 43 opcode = 221  parameter2 = %k1#Petrify% silent = 1 END
+    END
+BUT_ONLY
  
-
-  
 COPY_EXISTING ~spwi604.spl~ ~override~    
-WRITE_BYTE 0x27 "%k1#Petrify%" 
+    WRITE_BYTE 0x27 "%k1#Petrify%" 
 BUT_ONLY
  
 COPY_EXISTING ~spwi604d.spl~ ~override~    
-WRITE_BYTE 0x27 "%k1#Petrify%" 
+    WRITE_BYTE 0x27 "%k1#Petrify%" 
 BUT_ONLY 
 
 
 COPY_EXISTING_REGEXP GLOB ~.*\.itm$~ ~override~
-PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
-LPF CLONE_EFFECT INT_VAR multi_match = 1 match_opcode = 101 opcode = 206 match_parameter2 = 134  STR_VAR resource = spwi604d silent = 1 END 
-LPF CLONE_EFFECT INT_VAR multi_match = 1 match_opcode = 101 opcode = 206 match_parameter2 = 134  STR_VAR resource = spwi604  silent = 1 END 
-LPF DELETE_ITEM_EFFECT INT_VAR opcode_to_delete = 134 END
- END
+    PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
+        LPF CLONE_EFFECT INT_VAR multi_match = 1 match_opcode = 101 opcode = 206 match_parameter2 = 134 silent = 1 STR_VAR resource = "spwi604d" END 
+        LPF CLONE_EFFECT INT_VAR multi_match = 1 match_opcode = 101 opcode = 206 match_parameter2 = 134 silent = 1 STR_VAR resource = "spwi604" END 
+        LPF DELETE_ITEM_EFFECT INT_VAR opcode_to_delete = 134 END
+    END
 BUT_ONLY
 
 COPY_EXISTING_REGEXP GLOB ~.*\.spl$~ ~override~
-PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
-LPF CLONE_EFFECT INT_VAR multi_match = 1 match_opcode = 101 opcode = 206 match_parameter2 = 134  STR_VAR resource = spwi604d silent = 1 END 
-LPF CLONE_EFFECT INT_VAR multi_match = 1 match_opcode = 101 opcode = 206 match_parameter2 = 134  STR_VAR resource = spwi604  silent = 1 END
-LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 134 END
- END
+    PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
+        LPF CLONE_EFFECT INT_VAR multi_match = 1 match_opcode = 101 opcode = 206 match_parameter2 = 134 silent = 1 STR_VAR resource = "spwi604d" END 
+        LPF CLONE_EFFECT INT_VAR multi_match = 1 match_opcode = 101 opcode = 206 match_parameter2 = 134 silent = 1 STR_VAR resource = "spwi604" END
+        LPF DELETE_SPELL_EFFECT INT_VAR opcode_to_delete = 134 END
+    END
 BUT_ONLY
 
 COPY_EXISTING_REGEXP GLOB ~.*\.itm$~ ~override~
-PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
-LPF CLONE_EFFECT INT_VAR multi_match = 1 match_opcode = 83 opcode = 206 match_parameter2 = 64  STR_VAR resource = spwi604  silent = 1 END  
-LPF CLONE_EFFECT INT_VAR multi_match = 1 match_opcode = 83 opcode = 206 match_parameter2 = 64  STR_VAR resource = spwi604d silent = 1 END
- END
+    PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
+        LPF CLONE_EFFECT INT_VAR multi_match = 1 match_opcode = 83 opcode = 206 match_parameter2 = 64 silent = 1 STR_VAR resource = "spwi604" END  
+        LPF CLONE_EFFECT INT_VAR multi_match = 1 match_opcode = 83 opcode = 206 match_parameter2 = 64 silent = 1 STR_VAR resource = "spwi604d" END
+    END
 BUT_ONLY
 
 COPY_EXISTING_REGEXP GLOB ~.*\.spl$~ ~override~
-PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
-LPF CLONE_EFFECT INT_VAR multi_match = 1 match_opcode = 83 opcode = 206 match_parameter2 = 64  STR_VAR resource = spwi604d silent = 1 END  
-LPF CLONE_EFFECT INT_VAR multi_match = 1 match_opcode = 83 opcode = 206 match_parameter2 = 64  STR_VAR resource = spwi604  silent = 1 END
- END
+    PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
+        LPF CLONE_EFFECT INT_VAR multi_match = 1 match_opcode = 83 opcode = 206 match_parameter2 = 64 silent = 1 STR_VAR resource = "spwi604d" END  
+        LPF CLONE_EFFECT INT_VAR multi_match = 1 match_opcode = 83 opcode = 206 match_parameter2 = 64 silent = 1 STR_VAR resource = "spwi604" END
+    END
 BUT_ONLY


### PR DESCRIPTION
Fixing the drunken-school-of-indentation in several files along with similar issues, insofar as I had the patience to do it (100% consistency requires more work than I am willing to put in).

* cleaned up indentation, especially in the more egregious places
* standardized indentation with tabs = 4 spaces
* several tabs in middle of commands instead of single spaces
* missing "" in several places

To merge after testing install.

note(s):
* converted PR to draft as only merging after next public release.