### PR TITLE
Assorted fixes to kreso_eestat.tph

### DIFF
--- a/spell_rev/lib/kreso_eestatSR.tph
+++ b/spell_rev/lib/kreso_eestatSR.tph
@@ -3568,24 +3568,6 @@ LPF ADD_SPELL_EFFECT
 END
 END
 
-ACTION_IF FILE_EXISTS_IN_GAME ~%sppr311%.spl~ THEN BEGIN
-COPY_EXISTING ~%sppr311%.spl~ ~override~  
-LPF ADD_SPELL_EFFECT
-	INT_VAR
-	opcode			= 324
-	target			= 2
-	power			= 0
-	savingthrow     = 0
-	parameter1      = 41     // Chaotic commands
-	parameter2		= 110
-	duration        = 1
-	timing			= 0
-	insert_point    = 0
-	STR_VAR
-	resource        = EVAL ~%sppr311%~
-END
-END
-
 ACTION_IF FILE_EXISTS_IN_GAME ~sppr405.spl~ THEN BEGIN
 COPY_EXISTING ~sppr405.spl~ ~override~  
 LPF ADD_SPELL_EFFECT

--- a/spell_rev/lib/kreso_eestatSR.tph
+++ b/spell_rev/lib/kreso_eestatSR.tph
@@ -3186,22 +3186,22 @@ LPF ADD_SPELL_EFFECT
 END
 END
 
-ACTION_IF FILE_EXISTS_IN_GAME ~sppr416.spl~ THEN BEGIN
-COPY_EXISTING ~sppr416.spl~ ~override~   
-LPF ADD_SPELL_EFFECT
-	INT_VAR
-	opcode			= 324
-	target			= 2
-	power			= 0
-	savingthrow     = 0
-	parameter1      = 106   // fear immune
-	parameter2		= 110
-	duration        = 1
-	timing			= 0
-	insert_point    = 0
-	STR_VAR
-	resource        = sppr416
-END
+ACTION_IF FILE_EXISTS_IN_GAME ~sppr416d.spl~ THEN BEGIN
+	COPY_EXISTING ~sppr416d.spl~ ~override~   
+		LPF ADD_SPELL_EFFECT INT_VAR
+			//Remove effects by resource.
+			opcode = 324
+			target = 2
+			power = 0
+			savingthrow = 0
+			parameter1 = 106          //Fear immunity.
+			parameter2 = 110
+			duration = 1
+			timing = 0
+			insert_point = 0
+		STR_VAR
+			resource = "sppr416d"
+		END
 END
 
 ACTION_IF FILE_EXISTS_IN_GAME ~spwi125.spl~ THEN BEGIN


### PR DESCRIPTION
# Assorted fixes to kreso_eestatsr.tph

1. Contagion: blocking by Chaotic Commands is non-sensical. Removed.
2. Cloak of Fear: 324 opcode giving immunity on resist fear moved to aux spell.

TODO(s):
* Patching code for Melf's Acid Arrow is blocking all damage, not just acid. Change insertion point to "above" via CLONE_EFFECT as a stop gap solution?
* same for Flaming Arrow.
* similar issue with Incendiary Cloud.