### PR TITLE
Update arcane.tra

### DIFF
--- a/spell_rev/languages/english/arcane.tra
+++ b/spell_rev/languages/english/arcane.tra
@@ -741,6 +741,7 @@ Memorized Spells:
 @3518=~Hobgoblin Shaman~
 
 @519=~Non-Detection~
+// ***** the following description has been altered in English, needs translation
 @520=~Non-Detection
 Level: 3
 School: Abjuration
@@ -748,7 +749,7 @@ Casting Time: 3
 Area of Effect: 1 creature
 Saving Throw: None
 
-By casting this spell, the wizard makes the creature touched undetectable by divination spells such as Detect Invisibility, Oracle, and True Seeing, or by a thief's Detect Illusion ability, though an invisible person may still be audible when moving and his presence may still be sensed. Non-Detection wards the creature's gear as well as the creature itself.~
+By casting this spell, the wizard protects a hidden or invisible creature from being exposed by divinations that dispel invisibility, such as Invisibility Purge, Oracle, and True Seeing, or by a thief's Detect Illusion ability. Note: while a creature protected by Non-Detection cannot be exposed to everyone, they still may be observed and detected by individuals who, through a spell or innate ability, have the power to directly see through invisibility. This includes the caster - only the caster - of Detect Invisibility and True Seeing.~
 
 @521=~Protection from Missiles~
 @522=~Protection from Missiles


### PR DESCRIPTION
Proposed description for non-detection:

"By casting this spell, the wizard protects a hidden or invisible creature from being exposed by divinations that dispel invisibility, such as Invisibility Purge, Oracle, and True Seeing, or by a thief's Detect Illusion ability. Note: while a creature protected by Non-Detection cannot be exposed to everyone, they still may be observed and targeted by individuals who, through a spell or innate ability, have the power to directly see through invisibility. This includes the caster - only the caster - of Detect Invisibility and True Seeing."