### PR TITLE
stop enabling concentration checks

### DIFF
--- a/spell_rev/setup-spell_rev.tp2
+++ b/spell_rev/setup-spell_rev.tp2
@@ -91,12 +91,6 @@ ACTION_IF install_tobex && (ENGINE_IS ~tob~) BEGIN
     REPLACE_TEXTUALLY ~Apply Concentration Check On Damage=0~ ~Apply Concentration Check On Damage=1~
 END
 
-ACTION_IF FILE_EXISTS_IN_GAME ~concentr.2da~ BEGIN // EE v2.0+
-  COPY_EXISTING ~concentr.2da~ ~override~
-    SET_2DA_ENTRY 2 1 2 ~1~ // enable concentration check on EE games
-  BUT_ONLY
-END
-
 INCLUDE ~spell_rev/lib/ds.tph~
 
 // actual component


### PR DESCRIPTION
Somehow SR v4b18 has some code in the outer .TP2 file that enables concentration checks on EE 2.0+ games. I'm not sure when this was added or how I missed it, but concentration checks are bugged on all EE games from 2.0 right through 2.6. So this should be removed.