### PR TITLE
LABEL components

### DIFF
--- a/spell_rev/changelog.md
+++ b/spell_rev/changelog.md
@@ -45,6 +45,7 @@ The most salient ones are:
 17. [Avenger Cone of Cold -> Confusion](https://github.com/Gibberlings3/SpellRevisions/pull/90): SR changes the level 4 Avenger spell from Chaos to Cone of Cold. There is something to be said about this choice, but it has its downsides, not the least confusing SCS (in fairness, in part because it was implemented as a straight override) so it was decided to switch back to a spell that is closer to the original Chaos.
 18. [Fix dvbanish](https://github.com/Gibberlings3/SpellRevisions/pull/92)
 19. [French translation](https://github.com/Gibberlings3/SpellRevisions/pull/93): French translation files generously provided by mleduque.
+20. [LABEL components](https://github.com/Gibberlings3/SpellRevisions/pull/100): Add `LABEL` commands to every (non-deprecated) component.
 
 ## Earlier versions.
 

--- a/spell_rev/setup-spell_rev.tp2
+++ b/spell_rev/setup-spell_rev.tp2
@@ -79,6 +79,7 @@ LANGUAGE ~Polish by dradiel (djc@poczta.fm)~
 
 BEGIN @9996
 DESIGNATED 0
+LABEL "dv-spell_rev-main"
 REQUIRE_PREDICATE (ENGINE_IS ~soa tob bgee bg2ee eet iwdee~) @8996 // ~This mod is designed for the Baldur's Gate II engine and will not function on other games.~
 
 // ToBEx
@@ -128,6 +129,7 @@ END
 
 BEGIN @9995
 DESIGNATED 10
+LABEL "dv-spell_rev-deva_planetar_animations"
 REQUIRE_PREDICATE (ENGINE_IS ~tob bgee bg2ee eet~) @8997 // ~This component requires Baldur's Gate II: Throne of Bhaal be installed.~
 
 INCLUDE ~spell_rev/components/celestials.tpa~
@@ -141,6 +143,7 @@ INCLUDE ~spell_rev/components/celestials.tpa~
 
 BEGIN @9992
 DESIGNATED 20
+LABEL "dv-spell_rev-mirror_image_fix"
 REQUIRE_PREDICATE (ENGINE_IS ~soa tob bgee bg2ee iwdee~) @8996 // ~This mod is designed for the Baldur's Gate II engine and will not function on other games.~
 
 INCLUDE ~spell_rev/components/mirror_image_vs_aoe.tpa~
@@ -154,6 +157,7 @@ INCLUDE ~spell_rev/components/mirror_image_vs_aoe.tpa~
 
 BEGIN @9991
 DESIGNATED 30
+LABEL "dv-spell_rev-dispel_magic_fix"
 REQUIRE_PREDICATE (ENGINE_IS ~soa tob bgee bg2ee eet~) @8996 // ~This mod is designed for the Baldur's Gate II engine and will not function on other games.~
 
 INCLUDE ~spell_rev/components/dispellable_items.tpa~
@@ -205,8 +209,9 @@ DEPRECATED ~This feature is now included in the main component of the mod.~
 
 BEGIN ~Spell Deflection blocks AoE spells~
 DESIGNATED 55
-// removing 'bypassing MR' exploit and making spells affectable by spell protections
+LABEL "dv-spell_rev-nwn_style_spell_deflection"
 
+// removing 'bypassing MR' exploit and making spells affectable by spell protections
 INCLUDE ~spell_rev/components/nwn_spell_deflection.tpa~
 
 //\\//\\//\\//\\//\\//\\//\\//\\//\\//\\//\\//\\//\\//\\//\\//\\\\
@@ -218,6 +223,7 @@ INCLUDE ~spell_rev/components/nwn_spell_deflection.tpa~
 
 BEGIN @9989
 DESIGNATED 60
+LABEL "dv-spell_rev-update_npc_spellbooks"
 REQUIRE_PREDICATE (ENGINE_IS ~soa tob bgee bg2ee eet~) @8996 // ~This mod is designed for the Baldur's Gate II engine and will not function on other games.~
 REQUIRE_COMPONENT ~setup-spell_rev.tp2~ 0 @8999 // ~This component requires that the main Spell Revisions component be installed.~
 
@@ -242,8 +248,8 @@ INCLUDE ~spell_rev/components/fix_arcane_spellbooks.tpa~
 /*--------Revised HLAs----------------*/
 BEGIN @10000
 DESIGNATED 65
+LABEL "dv-spell_rev-revised_hlas"
 REQUIRE_PREDICATE (ENGINE_IS ~soa tob bg2ee eet~) @8996 // ~This mod is designed for the Baldur's Gate II engine and will not function on other games.~
 INCLUDE ~spell_rev/lib/kreso_hla.tph~
 
 PRINT @7998 // ~Done!~
-


### PR DESCRIPTION
Add `LABEL` to every (non-deprecated) component.

The naming scheme used is: "modder_prefix-mod_name-component_name" with modder_prefix "dv" and mod_name "spell_rev". Component names are:

* main
* deva_planetar_animations
* mirror_image_fix
* dispel_magic_fix
* nwn_style_spell_deflection
* update_npc_spellbooks
* revised_hlas