### PR TITLE
New component: revised saving throws

### DIFF
--- a/spell_rev/changelog.md
+++ b/spell_rev/changelog.md
@@ -56,7 +56,8 @@ The most salient ones are:
 28. [Patch inquisitor true seeing](https://github.com/Gibberlings3/SpellRevisions/pull/119):
 29. [Wrong dice in Talos' Lightning Bolt](https://github.com/Gibberlings3/SpellRevisions/pull/124): a sleuth of fixes to the Cleric of Talos' version of Lightning Bolt (more than the title suggests).
 30. [rc5 fixes](https://github.com/Gibberlings3/SpellRevisions/pull/132): patch by subtledoctor to fix issues with 232 opcodes in Sleep, Magic Fang, etc.
-31. [Find Traps fix](https://github.com/Gibberlings3/SpellRevisions/pull/138):
+31. [Find Traps fix](https://github.com/Gibberlings3/SpellRevisions/pull/138): Fix a targeting bug in the cleric Find Traps spell.
+32. [Saves Component](https://github.com/Gibberlings3/SpellRevisions/pull/139): the code copying the new, revised saving throw tables has been relegated to its own component. 
 
 ## Earlier versions.
 

--- a/spell_rev/components/main_component.tpa
+++ b/spell_rev/components/main_component.tpa
@@ -3496,19 +3496,6 @@ COPY_EXISTING ~25spell.sto~ ~override~ // Arcana Archives
   END
   BUT_ONLY_IF_IT_CHANGES-----------------*/
 
-
-/*------ REVISED SAVES ------*/
-
-COPY ~spell_rev/revised_saves/savewar.2da~ ~override~  // Warrior saves
-COPY ~spell_rev/revised_saves/savemonk.2da~ ~override~  // Monk saves
-COPY ~spell_rev/revised_saves/saverog.2da~ ~override~  // Rogue saves
-COPY ~spell_rev/revised_saves/saveprs.2da~ ~override~  // Priest saves
-COPY ~spell_rev/revised_saves/savewiz.2da~ ~override~  // Wizard saves
-
-COPY ~spell_rev/revised_saves/savecndh.2da~ ~override~  // Dwarf/Halfling save bonuses
-COPY ~spell_rev/revised_saves/savecng.2da~ ~override~  // Gnome save bonuses
-
-
 // added by SubtleDoctor:
 /*------ SET ARCANE SPELL SCHOOLS ------*/
 

--- a/spell_rev/components/saving_throw_tables.tpa
+++ b/spell_rev/components/saving_throw_tables.tpa
@@ -1,0 +1,19 @@
+//Resvised saves component.
+
+WITH_SCOPE BEGIN
+    ACTION_DEFINE_ASSOCIATIVE_ARRAY save_tables BEGIN
+        "Warrior"           => "savewar.2da"
+        "Monk"              => "savemonk.2da"
+        "Rogue"             => "saverog.2da"
+        "Priest"            => "saveprs.2da"
+        "Wizard"            => "savewiz.2da"
+        "Dwarf/Halfling"    => "savecndh.2da"
+        "Gnome"             => "savecng.2da"
+    END
+
+
+    OUTER_TEXT_SPRINT dir "spell_rev/revised_saves"
+    ACTION_PHP_EACH save_tables AS _ => file BEGIN
+        COPY "%dir%/%file%" "override"
+    END
+END

--- a/spell_rev/components/saving_throw_tables.tpa
+++ b/spell_rev/components/saving_throw_tables.tpa
@@ -1,5 +1,4 @@
-//Resvised saves component.
-
+//Revised saves component.
 WITH_SCOPE BEGIN
     ACTION_DEFINE_ASSOCIATIVE_ARRAY save_tables BEGIN
         "Warrior"           => "savewar.2da"
@@ -10,7 +9,6 @@ WITH_SCOPE BEGIN
         "Dwarf/Halfling"    => "savecndh.2da"
         "Gnome"             => "savecng.2da"
     END
-
 
     OUTER_TEXT_SPRINT dir "spell_rev/revised_saves"
     ACTION_PHP_EACH save_tables AS _ => file BEGIN

--- a/spell_rev/languages/english/setup.tra
+++ b/spell_rev/languages/english/setup.tra
@@ -28,3 +28,4 @@ A more powerful version of the Whirlwind Attack, Greater Whirlwind gives the fig
 
 Requires: Whirlwind Attack~
 
+@10010 = ~Revised Saving Throws~

--- a/spell_rev/setup-spell_rev.tp2
+++ b/spell_rev/setup-spell_rev.tp2
@@ -208,4 +208,9 @@ LABEL "dv-spell_rev-revised_hlas"
 REQUIRE_PREDICATE (ENGINE_IS ~soa tob bg2ee eet~) @8996 // ~This mod is designed for the Baldur's Gate II engine and will not function on other games.~
 INCLUDE ~spell_rev/lib/kreso_hla.tph~
 
-PRINT @7998 // ~Done!~
+//Revised saves.
+BEGIN @10010
+DESIGNATED 70
+LABEL "dv-spell_rev-revised_saving_throws"
+REQUIRE_PREDICATE (ENGINE_IS ~soa tob bg2ee eet~) @8996
+INCLUDE ~spell_rev/components/saving_throw_tables.tpa~


### PR DESCRIPTION
Segregate the copying of the new, revised saving throw tables, to its own component.

Minimal testing done (e.g. new install works). No more should be needed, since the patch just moves simply file copying from one place to another.